### PR TITLE
fix: pass doc comments from for-loop init to resolveExpr (closes #7)

### DIFF
--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -92,7 +92,7 @@ class SemanticAnalysisPass implements PassInterface
             $this->resolveExpr($stmt->cond);
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\For_) {
             foreach ($stmt->init as $init) {
-                $this->resolveExpr($init);
+                $this->resolveExpr($init, $init->getDocComment());
             }
             foreach ($stmt->cond as $cond) {
                 $condType = $this->resolveExpr($cond);

--- a/tests/Feature/ForLoopVarInitTest.php
+++ b/tests/Feature/ForLoopVarInitTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+it('supports @var declarations in for-loop init clause', function () {
+    $file = 'tests/programs/control_flow/for_loop_var_init.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/Feature/PostIncDecTest.php
+++ b/tests/Feature/PostIncDecTest.php
@@ -10,10 +10,10 @@ it('handles post-increment correctly', function () {
 
     $buildPath = config('app.build_path');
     assert(is_string($buildPath));
-    // compiled echo adds newlines after ints (known issue), so oracle comparison is not possible yet
-    // PHP outputs "56", compiled outputs "5\n6\n"
     $compiled_output = shell_exec("{$buildPath}/a.out");
-    expect($compiled_output)->toBe("5\n6\n");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
 });
 
 it('handles post-decrement correctly', function () {
@@ -25,7 +25,9 @@ it('handles post-decrement correctly', function () {
     $buildPath = config('app.build_path');
     assert(is_string($buildPath));
     $compiled_output = shell_exec("{$buildPath}/a.out");
-    expect($compiled_output)->toBe("5\n4\n");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
 });
 
 it('handles post-increment in for loop correctly', function () {
@@ -37,5 +39,7 @@ it('handles post-increment in for loop correctly', function () {
     $buildPath = config('app.build_path');
     assert(is_string($buildPath));
     $compiled_output = shell_exec("{$buildPath}/a.out");
-    expect($compiled_output)->toBe("0\n1\n2\n3\n4\n");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
 });

--- a/tests/programs/control_flow/for_loop_var_init.php
+++ b/tests/programs/control_flow/for_loop_var_init.php
@@ -1,0 +1,11 @@
+<?php
+
+function test_for_var_init(): int
+{
+    for (/** @var int */ $i = 0; $i < 5; $i++) {
+        echo $i;
+    }
+    return 0;
+}
+
+test_for_var_init();


### PR DESCRIPTION
Implements #7

## Changes

**SemanticAnalysisPass.php**: For-loop init expressions now pass their doc comment to `resolveExpr()`, enabling `/** @var int */ $i = 0` inside `for()` init clauses.

**PostIncDecTest.php**: Updated to use oracle comparison (compiled output === php output) now that the echo newline fix (#9) is merged.

## Test Results
```
PASS  Tests\Feature\BuildTest
PASS  Tests\Feature\EchoTest
PASS  Tests\Feature\ForLoopVarInitTest
PASS  Tests\Feature\PhpCeptionTest
PASS  Tests\Feature\PostIncDecTest
PASS  Tests\Unit\ClassConverterTest
PASS  Tests\Unit\LLVMValueTest
FAIL  Tests\Unit\PhpDocTest  (pre-existing, #5)
PASS  Tests\Unit\SymbolTableTest
PASS  Tests\Unit\TreeNodeTest

Tests: 1 failed, 18 passed (53 assertions)
```

## New Test Programs
- `tests/programs/control_flow/for_loop_var_init.php`

## Notes
- The `rType` fallback in `resolveExpr` already handles the simple `$i = 0` case (infers type from the literal), so the `@var` annotation is technically redundant for int literals. However, forwarding the doc comment is the correct behavior and would matter when the annotation specifies a different type than the literal (e.g., `/** @var float */ $x = 0`).