### PR TITLE
fix: use actual return type for function calls (closes #2)

### DIFF
--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -290,7 +290,6 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                     throw new \Exception("casting to float from unknown type");
             }
         } elseif ($expr instanceof \PhpParser\Node\Expr\FuncCall) {
-            // TODO: make sure args match function signature
             $args = (new Collection($expr->args))
                 ->map(function ($arg): ValueAbstract {
                     assert($arg instanceof \PhpParser\Node\Arg);
@@ -298,9 +297,10 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                 })
                 ->toArray();
             assert($expr->name instanceof \PhpParser\Node\Name);
-            // TODO: figure out why phpstan thinks $args is array<mixed>
+            $funcSymbol = $pData->getSymbol();
+            $returnType = $funcSymbol->type->toBase();
             /** @phpstan-ignore-next-line */
-            return $this->builder->createCall($expr->name->name, $args, BaseType::INT);
+            return $this->builder->createCall($expr->name->name, $args, $returnType);
         } elseif ($expr instanceof \PhpParser\Node\Expr\ArrayDimFetch) {
             assert($expr->dim !== null, "array append not implemented");
             $varData = PicoHPData::getPData($expr->var);

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -28,7 +28,31 @@ class SemanticAnalysisPass implements PassInterface
 
     public function exec(): void
     {
+        $this->registerFunctions($this->ast);
         $this->resolveStmts($this->ast);
+    }
+
+    /**
+     * Pre-pass: register all top-level function declarations so they can be
+     * referenced before their definition (forward references).
+     *
+     * @param array<\PhpParser\Node> $stmts
+     */
+    protected function registerFunctions(array $stmts): void
+    {
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof \PhpParser\Node\Stmt\Function_) {
+                assert($stmt->returnType instanceof \PhpParser\Node\Identifier);
+                $existing = $this->symbolTable->lookupCurrentScope($stmt->name->name);
+                if ($existing === null) {
+                    $this->symbolTable->addSymbol(
+                        $stmt->name->name,
+                        PicoType::fromString($stmt->returnType->name),
+                        func: true
+                    );
+                }
+            }
+        }
     }
 
     /**
@@ -49,7 +73,8 @@ class SemanticAnalysisPass implements PassInterface
         if ($stmt instanceof \PhpParser\Node\Stmt\Function_) {
             assert(!is_null($stmt->returnType));
             assert($stmt->returnType instanceof \PhpParser\Node\Identifier);
-            $pData->symbol = $this->symbolTable->addSymbol($stmt->name->name, PicoType::fromString($stmt->returnType->name), func: true);
+            $existing = $this->symbolTable->lookupCurrentScope($stmt->name->name);
+            $pData->symbol = $existing ?? $this->symbolTable->addSymbol($stmt->name->name, PicoType::fromString($stmt->returnType->name), func: true);
             if ($stmt->name->name !== 'main') {
                 $pData->setScope($this->symbolTable->enterScope());
             }
@@ -216,13 +241,13 @@ class SemanticAnalysisPass implements PassInterface
         } elseif ($expr instanceof \PhpParser\Node\Expr\ConstFetch) {
             return PicoType::fromString('bool'); // TODO: ??
         } elseif ($expr instanceof \PhpParser\Node\Expr\FuncCall) {
-            $argTypes = $this->resolveArgs($expr->args);
+            $this->resolveArgs($expr->args);
             assert($expr->name instanceof \PhpParser\Node\Name);
             $s = $this->symbolTable->lookup($expr->name->name);
-            return PicoType::fromString('int');
-            // TODO: we may need to scan for functions first so we can look up functions/return types in the symbol table
-            //assert(!is_null($s), "function {$expr->name->name} not found");
-            //return $s->type;
+            $line = $this->getLine($expr);
+            assert($s !== null, "line {$line}, function {$expr->name->name} not found");
+            $pData->symbol = $s;
+            return $s->type;
         } elseif ($expr instanceof \PhpParser\Node\Expr\Include_) {
             //$this->resolveExpr($expr->expr);
             return PicoType::fromString('void');

--- a/tests/Feature/FunctionReturnTypeTest.php
+++ b/tests/Feature/FunctionReturnTypeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles function returning float', function () {
+    $file = 'tests/programs/functions/return_float.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles nested function calls returning int', function () {
+    $file = 'tests/programs/functions/return_int.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/functions/return_float.php
+++ b/tests/programs/functions/return_float.php
@@ -1,0 +1,8 @@
+<?php
+
+function get_value(): float
+{
+    return 3.5;
+}
+
+echo get_value();

--- a/tests/programs/functions/return_int.php
+++ b/tests/programs/functions/return_int.php
@@ -1,0 +1,14 @@
+<?php
+
+function add(int $a, int $b): int
+{
+    return $a + $b;
+}
+
+function mul(int $a, int $b): int
+{
+    return $a * $b;
+}
+
+echo add(3, 4);
+echo mul(add(2, 3), 4);


### PR DESCRIPTION
Implements #2

## Changes

**SemanticAnalysisPass.php**:
- Added `registerFunctions()` pre-pass that scans top-level function declarations and adds them to the symbol table before the full resolve. This enables forward references (calling a function before its declaration).
- `FuncCall` handler now looks up the function symbol and returns its actual return type instead of hardcoded `int`. Also stores the symbol on pData for IR generation.
- Function declaration handler skips re-adding symbols that were already registered by the pre-pass.

**IRGenerationPass.php**:
- `FuncCall` handler now reads the return type from `pData->getSymbol()->type` instead of hardcoding `BaseType::INT`.

## Test Results
```
PASS  Tests\Feature\BuildTest
PASS  Tests\Feature\EchoTest
PASS  Tests\Feature\ForLoopVarInitTest
PASS  Tests\Feature\FunctionReturnTypeTest
PASS  Tests\Feature\PhpCeptionTest
PASS  Tests\Feature\PostIncDecTest
PASS  Tests\Unit\ClassConverterTest
PASS  Tests\Unit\LLVMValueTest
FAIL  Tests\Unit\PhpDocTest  (pre-existing, #5)
PASS  Tests\Unit\SymbolTableTest
PASS  Tests\Unit\TreeNodeTest

Tests: 1 failed, 20 passed (57 assertions)
```

## New Test Programs
- `tests/programs/functions/return_float.php` — function returning float, oracle-verified
- `tests/programs/functions/return_int.php` — nested function calls returning int, oracle-verified