### PR TITLE
fix: support void function calls and implicit ret void (closes #13)

### DIFF
--- a/app/PicoHP/LLVM/Builder.php
+++ b/app/PicoHP/LLVM/Builder.php
@@ -137,6 +137,10 @@ class Builder
         $paramString = (new Collection($paramVals))
             ->map(fn ($param): string => "{$param->getType()->toLLVM()} {$param->render()}")
             ->join(', ');
+        if ($returnType === BaseType::VOID) {
+            $this->addLine("call void @{$functionName} ({$paramString})", 1);
+            return new Void_();
+        }
         $returnVal = new Instruction('call', $returnType);
         $this->addLine("{$returnVal->render()} = call {$returnType->toLLVM()} @{$functionName} ({$paramString})", 1);
         return $returnVal;
@@ -148,6 +152,11 @@ class Builder
         $resultVal = new Instruction('getelementptr', BaseType::PTR);
         $this->addLine("{$resultVal->render()} = getelementptr inbounds {$arrayType->toLLVM()}, ptr {$var->render()}, i64 0, {$dim->getType()->toLLVM()} {$dim->render()}", 1);
         return $resultVal;
+    }
+
+    public function createRetVoid(): void
+    {
+        $this->addLine('ret void', 1);
     }
 
     // public function createGlobal(string $name, ValueAbstract $val): ValueAbstract

--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -66,6 +66,9 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             }
             $this->buildParams($stmt->params);
             $this->buildStmts($stmt->stmts);
+            if ($funcSymbol->type->toBase() === BaseType::VOID) {
+                $this->builder->createRetVoid();
+            }
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Block) {
             $scope = $pData->getScope();
             foreach ($scope->symbols as $symbol) {

--- a/tests/Feature/VoidFunctionTest.php
+++ b/tests/Feature/VoidFunctionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles void function calls', function () {
+    $file = 'tests/programs/functions/void_function.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/functions/void_function.php
+++ b/tests/programs/functions/void_function.php
@@ -1,0 +1,14 @@
+<?php
+
+function print_value(int $x): void
+{
+    echo $x;
+}
+
+function print_twice(int $x): void
+{
+    print_value($x);
+    print_value($x);
+}
+
+print_twice(42);


### PR DESCRIPTION
Implements #13

## Changes

**Builder.php**:
- `createCall()` now handles void return type: emits `call void @func()` without assigning to a result register, returns `Void_`
- Added `createRetVoid()` method

**IRGenerationPass.php**:
- Void functions automatically get `ret void` appended after their body statements

## Test Results
```
21 passed, 1 failed (pre-existing PhpDocTest)
```

## New Test Programs
- `tests/programs/functions/void_function.php` — void functions calling other void functions, oracle-verified