### PR TITLE
fix: echo of bool matches PHP behavior (closes #14)

### DIFF
--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -87,7 +87,22 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Echo_) {
             foreach ($stmt->exprs as $expr) {
                 $val = $this->buildExpr($expr);
-                $this->builder->createCallPrintf($val);
+                if ($val->getType() === BaseType::BOOL) {
+                    assert($this->currentFunction !== null);
+                    $count = $pData->mycount;
+                    $printBB = $this->currentFunction->addBasicBlock("echo_bool{$count}");
+                    $endBB = $this->currentFunction->addBasicBlock("echo_end{$count}");
+                    $printLabel = new Label($printBB->getName());
+                    $endLabel = new Label($endBB->getName());
+                    $this->builder->createBranch([$val, $printLabel, $endLabel]);
+                    $this->builder->setInsertPoint($printBB);
+                    $intVal = $this->builder->createZext($val);
+                    $this->builder->createCallPrintf($intVal);
+                    $this->builder->createBranch([$endLabel]);
+                    $this->builder->setInsertPoint($endBB);
+                } else {
+                    $this->builder->createCallPrintf($val);
+                }
             }
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\If_) {
             $cond = $this->buildExpr($stmt->cond);

--- a/tests/Feature/EchoBoolTest.php
+++ b/tests/Feature/EchoBoolTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+it('echoes bools matching PHP behavior', function () {
+    $file = 'tests/programs/echo/echo_bool.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/echo/echo_bool.php
+++ b/tests/programs/echo/echo_bool.php
@@ -1,0 +1,11 @@
+<?php
+
+function test_echo_bool(): int
+{
+    echo true;
+    echo false;
+    echo true;
+    return 0;
+}
+
+test_echo_bool();


### PR DESCRIPTION
Implements #14

## Changes

**IRGenerationPass.php**: Echo of bool values now generates a conditional branch:
- If true: zero-extend to i32 and printf (outputs `1`)
- If false: skip the printf entirely (outputs nothing)

This matches PHP's behavior where `echo true` outputs `1` and `echo false` outputs empty string.

## Test Results
```
21 passed, 1 failed (pre-existing PhpDocTest)
```

## New Test Programs
- `tests/programs/echo/echo_bool.php` — echo true/false/true, oracle-verified