### PR TITLE
fix: require ext-mbstring, ext-dom, ext-xml in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
         "phpstan/phpdoc-parser": "^2.0",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
+        "ext-dom": "*",
         "ext-mbstring": "*",
+        "ext-xml": "*",
         "laravel/tinker": "^2.10"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5496c290c433c5003ee226e0b8dffdcf",
+    "content-hash": "5abd8328f2e9487b5405c5f333e7a620",
     "packages": [
         {
             "name": "brick/math",
@@ -8378,7 +8378,9 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2.0",
-        "ext-mbstring": "*"
+        "ext-dom": "*",
+        "ext-mbstring": "*",
+        "ext-xml": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"


### PR DESCRIPTION
## Summary
- Add `ext-mbstring`, `ext-dom`, and `ext-xml` to the `require` section of `composer.json`
- Ensures `composer install` fails early with a clear error when these extensions are missing
- Closes #15

## Test plan
- [ ] Run `composer validate` — should pass
- [ ] On a system missing ext-mbstring, `composer install` should error clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)