### PR TITLE
feat: comparison and logical operators (closes #1)

### DIFF
--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -221,9 +221,16 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             }
             return $this->builder->createLoad($value);
         } elseif ($expr instanceof \PhpParser\Node\Expr\BinaryOp) {
+            $sigil = $expr->getOperatorSigil();
+
+            // Short-circuit evaluation for && and ||
+            if ($sigil === '&&' || $sigil === '||') {
+                return $this->buildShortCircuit($expr, $pData);
+            }
+
             $lval = $this->buildExpr($expr->left);
             $rval = $this->buildExpr($expr->right);
-            switch ($expr->getOperatorSigil()) {
+            switch ($sigil) {
                 case '+':
                     $val = $this->builder->createInstruction('add', [$lval, $rval]);
                     break;
@@ -249,7 +256,12 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                     $val = $this->builder->createInstruction('ashr', [$lval, $rval]);
                     break;
                 case '==':
+                case '===':
                     $val = $this->builder->createInstruction('icmp eq', [$lval, $rval], resultType: BaseType::BOOL);
+                    break;
+                case '!=':
+                case '!==':
+                    $val = $this->builder->createInstruction('icmp ne', [$lval, $rval], resultType: BaseType::BOOL);
                     break;
                 case '<':
                     $val = $this->builder->createInstruction('icmp slt', [$lval, $rval], resultType: BaseType::BOOL);
@@ -257,8 +269,14 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                 case '>':
                     $val = $this->builder->createInstruction('icmp sgt', [$lval, $rval], resultType: BaseType::BOOL);
                     break;
+                case '<=':
+                    $val = $this->builder->createInstruction('icmp sle', [$lval, $rval], resultType: BaseType::BOOL);
+                    break;
+                case '>=':
+                    $val = $this->builder->createInstruction('icmp sge', [$lval, $rval], resultType: BaseType::BOOL);
+                    break;
                 default:
-                    throw new \Exception("unknown BinaryOp {$expr->getOperatorSigil()}");
+                    throw new \Exception("unknown BinaryOp {$sigil}");
             }
             return $val;
         } elseif ($expr instanceof \PhpParser\Node\Expr\UnaryMinus) {
@@ -353,6 +371,36 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
         } else {
             throw new \Exception("unknown node type in expr: " . get_class($expr));
         }
+    }
+
+    protected function buildShortCircuit(\PhpParser\Node\Expr\BinaryOp $expr, PicoHPData $pData): ValueAbstract
+    {
+        assert($this->currentFunction !== null);
+        $isAnd = $expr->getOperatorSigil() === '&&';
+        $count = $pData->mycount;
+
+        $rhsBB = $this->currentFunction->addBasicBlock("sc_rhs{$count}");
+        $endBB = $this->currentFunction->addBasicBlock("sc_end{$count}");
+        $rhsLabel = new Label($rhsBB->getName());
+        $endLabel = new Label($endBB->getName());
+
+        $result = $this->builder->createAlloca("sc_result{$count}", BaseType::BOOL);
+        $lval = $this->buildExpr($expr->left);
+        $this->builder->createStore($lval, $result);
+
+        if ($isAnd) {
+            $this->builder->createBranch([$lval, $rhsLabel, $endLabel]);
+        } else {
+            $this->builder->createBranch([$lval, $endLabel, $rhsLabel]);
+        }
+
+        $this->builder->setInsertPoint($rhsBB);
+        $rval = $this->buildExpr($expr->right);
+        $this->builder->createStore($rval, $result);
+        $this->builder->createBranch([$endLabel]);
+
+        $this->builder->setInsertPoint($endBB);
+        return $this->builder->createLoad($result);
     }
 
     /**

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -204,8 +204,15 @@ class SemanticAnalysisPass implements PassInterface
                     $type = $rtype;
                     break;
                 case '==':
+                case '===':
+                case '!=':
+                case '!==':
                 case '<':
                 case '>':
+                case '<=':
+                case '>=':
+                case '&&':
+                case '||':
                     $type = PicoType::fromString('bool');
                     break;
                 default:

--- a/tests/Feature/ComparisonTest.php
+++ b/tests/Feature/ComparisonTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+$programs = [
+    'less than or equal' => 'tests/programs/comparison/less_equal.php',
+    'greater than or equal' => 'tests/programs/comparison/greater_equal.php',
+    'not equal' => 'tests/programs/comparison/not_equal.php',
+    'logical and' => 'tests/programs/comparison/logical_and.php',
+    'logical or' => 'tests/programs/comparison/logical_or.php',
+    'combined comparison and logic' => 'tests/programs/comparison/combined.php',
+];
+
+foreach ($programs as $name => $file) {
+    it("compiles {$name} operators correctly", function () use ($file) {
+        /** @phpstan-ignore-next-line */
+        $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+        $buildPath = config('app.build_path');
+        assert(is_string($buildPath));
+        $compiled_output = shell_exec("{$buildPath}/a.out");
+        $php_output = shell_exec("php {$file}");
+
+        expect($compiled_output)->toBe($php_output);
+    });
+}

--- a/tests/programs/comparison/combined.php
+++ b/tests/programs/comparison/combined.php
@@ -1,0 +1,19 @@
+<?php
+
+function test_combined(): int
+{
+    /** @var int $x */
+    $x = 5;
+    /** @var int $y */
+    $y = 3;
+    /** @var int $z */
+    $z = 10;
+
+    echo $x >= 1 && $x <= $z;
+    echo $x >= 1 && $x <= $y;
+    echo $x !== $x + $y || $x > $y;
+    echo $x !== $x + $y || $x > $z;
+    return 0;
+}
+
+test_combined();

--- a/tests/programs/comparison/greater_equal.php
+++ b/tests/programs/comparison/greater_equal.php
@@ -1,0 +1,18 @@
+<?php
+
+function test_greater_equal(): int
+{
+    /** @var int $a */
+    $a = 3;
+    /** @var int $b */
+    $b = 2;
+    /** @var int $c */
+    $c = 2;
+
+    echo $a >= $b;
+    echo $b >= $c;
+    echo $b >= $a;
+    return 0;
+}
+
+test_greater_equal();

--- a/tests/programs/comparison/less_equal.php
+++ b/tests/programs/comparison/less_equal.php
@@ -1,0 +1,18 @@
+<?php
+
+function test_less_equal(): int
+{
+    /** @var int $a */
+    $a = 1;
+    /** @var int $b */
+    $b = 2;
+    /** @var int $c */
+    $c = 2;
+
+    echo $a <= $b;
+    echo $b <= $c;
+    echo $b <= $a;
+    return 0;
+}
+
+test_less_equal();

--- a/tests/programs/comparison/logical_and.php
+++ b/tests/programs/comparison/logical_and.php
@@ -1,0 +1,16 @@
+<?php
+
+function test_logical_and(): int
+{
+    /** @var int $a */
+    $a = 1;
+    /** @var int $b */
+    $b = 0;
+
+    echo $a > 0 && $a < 5;
+    echo $b > 0 && $a < 5;
+    echo $a > 0 && $b > 0;
+    return 0;
+}
+
+test_logical_and();

--- a/tests/programs/comparison/logical_or.php
+++ b/tests/programs/comparison/logical_or.php
@@ -1,0 +1,18 @@
+<?php
+
+function test_logical_or(): int
+{
+    /** @var int $a */
+    $a = 1;
+    /** @var int $b */
+    $b = 0;
+    /** @var int $c */
+    $c = -1;
+
+    echo $a > 0 || $b > 0;
+    echo $b > 0 || $a > 0;
+    echo $c > 0 || $b > 0;
+    return 0;
+}
+
+test_logical_or();

--- a/tests/programs/comparison/not_equal.php
+++ b/tests/programs/comparison/not_equal.php
@@ -1,0 +1,17 @@
+<?php
+
+function test_not_equal(): int
+{
+    /** @var int $a */
+    $a = 1;
+    /** @var int $b */
+    $b = 2;
+    /** @var int $c */
+    $c = 1;
+
+    echo $a !== $b;
+    echo $a !== $c;
+    return 0;
+}
+
+test_not_equal();


### PR DESCRIPTION
## Summary
- Add `<=` (`icmp sle`), `>=` (`icmp sge`), `!=`/`!==` (`icmp ne`), and `===` (`icmp eq`) operators
- Implement short-circuit evaluation for `&&` and `||` using basic block branching with alloca/store/load pattern
- 6 test programs covering each operator individually plus combined expressions

## Test plan
- [x] `vendor/bin/pest tests/Feature/ComparisonTest.php` — 6 tests pass
- [x] `vendor/bin/pest` — no regressions (28 pass, 1 pre-existing PhpDocTest failure)
- [x] `vendor/bin/phpstan` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)