### PR TITLE
feat: add modulo operator (closes #24)

### DIFF
--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -255,6 +255,9 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                 case '>>':
                     $val = $this->builder->createInstruction('ashr', [$lval, $rval]);
                     break;
+                case '%':
+                    $val = $this->builder->createInstruction('srem', [$lval, $rval]);
+                    break;
                 case '==':
                 case '===':
                     $val = $this->builder->createInstruction('icmp eq', [$lval, $rval], resultType: BaseType::BOOL);

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -201,6 +201,7 @@ class SemanticAnalysisPass implements PassInterface
                 case '|':
                 case '<<':
                 case '>>':
+                case '%':
                     $type = $rtype;
                     break;
                 case '==':

--- a/tests/Feature/ModuloTest.php
+++ b/tests/Feature/ModuloTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+it('compiles modulo operator correctly', function () {
+    $file = 'tests/programs/operators/modulo.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/operators/modulo.php
+++ b/tests/programs/operators/modulo.php
@@ -1,0 +1,18 @@
+<?php
+
+function test_modulo(): int
+{
+    /** @var int $a */
+    $a = 17;
+    /** @var int $b */
+    $b = 5;
+    /** @var int $c */
+    $c = 4;
+
+    echo $a % $b;
+    echo $a % $c;
+    echo $b % $b;
+    return 0;
+}
+
+test_modulo();


### PR DESCRIPTION
## Summary
- Add `%` operator support mapping to LLVM `srem` instruction
- Single case addition in both semantic analysis and IR generation passes

## Test plan
- [x] `vendor/bin/pest tests/Feature/ModuloTest.php` — passes
- [x] `vendor/bin/pest` — 31 tests pass, no regressions
- [x] `vendor/bin/phpstan` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)