### PR TITLE
feat: type-aware arithmetic and comparison operators (closes #25)

### DIFF
--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -230,18 +230,23 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
 
             $lval = $this->buildExpr($expr->left);
             $rval = $this->buildExpr($expr->right);
+            $isFloat = $lval->getType() === BaseType::FLOAT;
+            $operandType = $lval->getType();
             switch ($sigil) {
                 case '+':
-                    $val = $this->builder->createInstruction('add', [$lval, $rval]);
+                    $val = $this->builder->createInstruction($isFloat ? 'fadd' : 'add', [$lval, $rval], resultType: $operandType);
                     break;
                 case '*':
-                    $val = $this->builder->createInstruction('mul', [$lval, $rval]);
+                    $val = $this->builder->createInstruction($isFloat ? 'fmul' : 'mul', [$lval, $rval], resultType: $operandType);
                     break;
                 case '-':
-                    $val = $this->builder->createInstruction('sub', [$lval, $rval]);
+                    $val = $this->builder->createInstruction($isFloat ? 'fsub' : 'sub', [$lval, $rval], resultType: $operandType);
                     break;
                 case '/':
-                    $val = $this->builder->createInstruction('sdiv', [$lval, $rval]);
+                    $val = $this->builder->createInstruction($isFloat ? 'fdiv' : 'sdiv', [$lval, $rval], resultType: $operandType);
+                    break;
+                case '%':
+                    $val = $this->builder->createInstruction($isFloat ? 'frem' : 'srem', [$lval, $rval], resultType: $operandType);
                     break;
                 case '&':
                     $val = $this->builder->createInstruction('and', [$lval, $rval]);
@@ -255,28 +260,25 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                 case '>>':
                     $val = $this->builder->createInstruction('ashr', [$lval, $rval]);
                     break;
-                case '%':
-                    $val = $this->builder->createInstruction('srem', [$lval, $rval]);
-                    break;
                 case '==':
                 case '===':
-                    $val = $this->builder->createInstruction('icmp eq', [$lval, $rval], resultType: BaseType::BOOL);
+                    $val = $this->builder->createInstruction($isFloat ? 'fcmp oeq' : 'icmp eq', [$lval, $rval], resultType: BaseType::BOOL);
                     break;
                 case '!=':
                 case '!==':
-                    $val = $this->builder->createInstruction('icmp ne', [$lval, $rval], resultType: BaseType::BOOL);
+                    $val = $this->builder->createInstruction($isFloat ? 'fcmp one' : 'icmp ne', [$lval, $rval], resultType: BaseType::BOOL);
                     break;
                 case '<':
-                    $val = $this->builder->createInstruction('icmp slt', [$lval, $rval], resultType: BaseType::BOOL);
+                    $val = $this->builder->createInstruction($isFloat ? 'fcmp olt' : 'icmp slt', [$lval, $rval], resultType: BaseType::BOOL);
                     break;
                 case '>':
-                    $val = $this->builder->createInstruction('icmp sgt', [$lval, $rval], resultType: BaseType::BOOL);
+                    $val = $this->builder->createInstruction($isFloat ? 'fcmp ogt' : 'icmp sgt', [$lval, $rval], resultType: BaseType::BOOL);
                     break;
                 case '<=':
-                    $val = $this->builder->createInstruction('icmp sle', [$lval, $rval], resultType: BaseType::BOOL);
+                    $val = $this->builder->createInstruction($isFloat ? 'fcmp ole' : 'icmp sle', [$lval, $rval], resultType: BaseType::BOOL);
                     break;
                 case '>=':
-                    $val = $this->builder->createInstruction('icmp sge', [$lval, $rval], resultType: BaseType::BOOL);
+                    $val = $this->builder->createInstruction($isFloat ? 'fcmp oge' : 'icmp sge', [$lval, $rval], resultType: BaseType::BOOL);
                     break;
                 default:
                     throw new \Exception("unknown BinaryOp {$sigil}");

--- a/tests/Feature/FloatOperatorsTest.php
+++ b/tests/Feature/FloatOperatorsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+it('compiles float arithmetic correctly', function () {
+    $file = 'tests/programs/operators/float_arithmetic.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('compiles float comparison correctly', function () {
+    $file = 'tests/programs/operators/float_comparison.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/operators/float_arithmetic.php
+++ b/tests/programs/operators/float_arithmetic.php
@@ -1,0 +1,17 @@
+<?php
+
+function test_float_arithmetic(): int
+{
+    /** @var float $a */
+    $a = 3.5;
+    /** @var float $b */
+    $b = 1.5;
+
+    echo $a + $b;
+    echo $a - $b;
+    echo $a * $b;
+    echo $a / $b;
+    return 0;
+}
+
+test_float_arithmetic();

--- a/tests/programs/operators/float_comparison.php
+++ b/tests/programs/operators/float_comparison.php
@@ -1,0 +1,21 @@
+<?php
+
+function test_float_comparison(): int
+{
+    /** @var float $a */
+    $a = 3.5;
+    /** @var float $b */
+    $b = 1.5;
+    /** @var float $c */
+    $c = 3.5;
+
+    echo $a > $b;
+    echo $a < $b;
+    echo $a === $c;
+    echo $a !== $b;
+    echo $a >= $c;
+    echo $b <= $a;
+    return 0;
+}
+
+test_float_comparison();


### PR DESCRIPTION
## Summary
- Float arithmetic now uses `fadd`, `fsub`, `fmul`, `fdiv`, `frem` instead of integer `add`, `sub`, etc.
- Float comparisons now use `fcmp` ordered variants (`oeq`, `one`, `olt`, `ogt`, `ole`, `oge`) instead of `icmp`
- Result type correctly propagated from operand type (fixes float arithmetic results being treated as i32)

## Test plan
- [x] `vendor/bin/pest tests/Feature/FloatOperatorsTest.php` — 2 tests pass
- [x] `vendor/bin/pest` — 34 tests pass, no regressions
- [x] `vendor/bin/phpstan` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)