### PR TITLE
feat: pre-increment and pre-decrement operators

### DIFF
--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -373,6 +373,20 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             $newVal = $this->builder->createInstruction('sub', [$oldVal, new Constant(1, $oldVal->getType())]);
             $this->builder->createStore($newVal, $ptr);
             return $oldVal;
+        } elseif ($expr instanceof \PhpParser\Node\Expr\PreInc) {
+            $varPData = PicoHPData::getPData($expr->var);
+            $ptr = $varPData->getValue();
+            $oldVal = $this->builder->createLoad($ptr);
+            $newVal = $this->builder->createInstruction('add', [$oldVal, new Constant(1, $oldVal->getType())]);
+            $this->builder->createStore($newVal, $ptr);
+            return $newVal;
+        } elseif ($expr instanceof \PhpParser\Node\Expr\PreDec) {
+            $varPData = PicoHPData::getPData($expr->var);
+            $ptr = $varPData->getValue();
+            $oldVal = $this->builder->createLoad($ptr);
+            $newVal = $this->builder->createInstruction('sub', [$oldVal, new Constant(1, $oldVal->getType())]);
+            $this->builder->createStore($newVal, $ptr);
+            return $newVal;
         } else {
             throw new \Exception("unknown node type in expr: " . get_class($expr));
         }

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -270,6 +270,10 @@ class SemanticAnalysisPass implements PassInterface
             return $this->resolveExpr($expr->var);
         } elseif ($expr instanceof \PhpParser\Node\Expr\PostDec) {
             return $this->resolveExpr($expr->var);
+        } elseif ($expr instanceof \PhpParser\Node\Expr\PreInc) {
+            return $this->resolveExpr($expr->var);
+        } elseif ($expr instanceof \PhpParser\Node\Expr\PreDec) {
+            return $this->resolveExpr($expr->var);
         } else {
             $line = $this->getLine($expr);
             throw new \Exception("line {$line}, unknown node type in expr resolver: " . get_class($expr));

--- a/tests/Feature/PreIncDecTest.php
+++ b/tests/Feature/PreIncDecTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles pre-increment correctly', function () {
+    $file = 'tests/programs/operators/pre_increment.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles pre-decrement correctly', function () {
+    $file = 'tests/programs/operators/pre_decrement.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/operators/pre_decrement.php
+++ b/tests/programs/operators/pre_decrement.php
@@ -1,0 +1,14 @@
+<?php
+
+function test_predec(): int
+{
+    /** @var int */
+    $i = 5;
+    /** @var int */
+    $result = --$i;
+    echo $result;
+    echo $i;
+    return 0;
+}
+
+test_predec();

--- a/tests/programs/operators/pre_increment.php
+++ b/tests/programs/operators/pre_increment.php
@@ -1,0 +1,14 @@
+<?php
+
+function test_preinc(): int
+{
+    /** @var int */
+    $i = 5;
+    /** @var int */
+    $result = ++$i;
+    echo $result;
+    echo $i;
+    return 0;
+}
+
+test_preinc();


### PR DESCRIPTION
## Summary
- Add `++$i` (pre-increment) and `--$i` (pre-decrement) support to both SemanticAnalysisPass and IRGenerationPass
- Unlike post-inc/dec which returns the old value, pre-inc/dec returns the **new** value after modification
- Oracle-based tests verify compiled output matches PHP interpreter

## Test plan
- [x] `tests/programs/operators/pre_increment.php` — verifies `++$i` returns new value
- [x] `tests/programs/operators/pre_decrement.php` — verifies `--$i` returns new value
- [x] PHPStan passes at level max
- [x] Pint passes
- [ ] CI coverage ≥ 95%

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)