### PR TITLE
feat: elseif support in if statements

### DIFF
--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -108,23 +108,67 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                 }
             }
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\If_) {
-            $cond = $this->buildExpr($stmt->cond);
             assert($this->currentFunction !== null);
-            $thenBB = $this->currentFunction->addBasicBlock("then{$pData->mycount}");
-            $elseBB = $this->currentFunction->addBasicBlock("else{$pData->mycount}");
-            $endBB = $this->currentFunction->addBasicBlock("end{$pData->mycount}");
-            $thenLabel = new Label($thenBB->getName());
-            $elseLabel = new Label($elseBB->getName());
+            $currentFunction = $this->currentFunction;
+            $count = $pData->mycount;
+            $endBB = $currentFunction->addBasicBlock("end{$count}");
             $endLabel = new Label($endBB->getName());
-            $this->builder->createBranch([$cond, $thenLabel, $elseLabel]);
+
+            $thenBB = $currentFunction->addBasicBlock("then{$count}");
+            $thenLabel = new Label($thenBB->getName());
+
+            // Determine where to branch on false: first elseif, else, or end
+            $elseifCount = count($stmt->elseifs);
+            if ($elseifCount > 0) {
+                $nextBB = $currentFunction->addBasicBlock("elseif_cond{$count}_0");
+            } elseif (!is_null($stmt->else)) {
+                $nextBB = $currentFunction->addBasicBlock("else{$count}");
+            } else {
+                $nextBB = $endBB;
+            }
+            $nextLabel = new Label($nextBB->getName());
+
+            $cond = $this->buildExpr($stmt->cond);
+            $this->builder->createBranch([$cond, $thenLabel, $nextLabel]);
+
+            // then block
             $this->builder->setInsertPoint($thenBB);
             $this->buildStmts($stmt->stmts);
             $this->builder->createBranch([$endLabel]);
-            $this->builder->setInsertPoint($elseBB);
-            if (!is_null($stmt->else)) {
-                $this->buildStmts($stmt->else->stmts);
+
+            // elseif blocks
+            for ($i = 0; $i < $elseifCount; $i++) {
+                $elseif = $stmt->elseifs[$i];
+                $this->builder->setInsertPoint($nextBB);
+                $elseifCond = $this->buildExpr($elseif->cond);
+
+                $bodyBB = $currentFunction->addBasicBlock("elseif_body{$count}_{$i}");
+                $bodyLabel = new Label($bodyBB->getName());
+
+                // Determine next target after this elseif
+                if ($i + 1 < $elseifCount) {
+                    $nextBB = $currentFunction->addBasicBlock("elseif_cond{$count}_" . ($i + 1));
+                } elseif (!is_null($stmt->else)) {
+                    $nextBB = $currentFunction->addBasicBlock("else{$count}");
+                } else {
+                    $nextBB = $endBB;
+                }
+                $nextLabel = new Label($nextBB->getName());
+
+                $this->builder->createBranch([$elseifCond, $bodyLabel, $nextLabel]);
+
+                $this->builder->setInsertPoint($bodyBB);
+                $this->buildStmts($elseif->stmts);
+                $this->builder->createBranch([$endLabel]);
             }
-            $this->builder->createBranch([$endLabel]);
+
+            // else block
+            if (!is_null($stmt->else)) {
+                $this->builder->setInsertPoint($nextBB);
+                $this->buildStmts($stmt->else->stmts);
+                $this->builder->createBranch([$endLabel]);
+            }
+
             $this->builder->setInsertPoint($endBB);
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\While_) {
             assert($this->currentFunction !== null);

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -113,6 +113,10 @@ class SemanticAnalysisPass implements PassInterface
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\If_) {
             $this->resolveExpr($stmt->cond);
             $this->resolveStmts($stmt->stmts);
+            foreach ($stmt->elseifs as $elseif) {
+                $this->resolveExpr($elseif->cond);
+                $this->resolveStmts($elseif->stmts);
+            }
             if (!is_null($stmt->else)) {
                 $this->resolveStmts($stmt->else->stmts);
             }

--- a/tests/Feature/ElseifTest.php
+++ b/tests/Feature/ElseifTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles elseif correctly', function () {
+    $file = 'tests/programs/control/elseif.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/control/elseif.php
+++ b/tests/programs/control/elseif.php
@@ -1,0 +1,20 @@
+<?php
+
+function test_elseif(int $x): int
+{
+    if ($x > 10) {
+        echo 3;
+    } elseif ($x > 5) {
+        echo 2;
+    } elseif ($x > 0) {
+        echo 1;
+    } else {
+        echo 0;
+    }
+    return 0;
+}
+
+test_elseif(15);
+test_elseif(7);
+test_elseif(3);
+test_elseif(-1);


### PR DESCRIPTION
## Summary
- Add `elseif` support to both SemanticAnalysisPass and IRGenerationPass
- Each elseif gets its own condition-check and body basic blocks, chained between then and else/end
- Handles any number of elseif branches with proper fall-through

## Test plan
- [x] `tests/programs/control/elseif.php` — tests multiple elseif branches with different values
- [x] PHPStan passes at level max
- [x] Pint passes
- [ ] CI coverage ≥ 95%

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)