### PR TITLE
feat: string concatenation (.) operator

### DIFF
--- a/app/PicoHP/LLVM/Builder.php
+++ b/app/PicoHP/LLVM/Builder.php
@@ -27,8 +27,10 @@ class Builder
         $this->addLine('@.str.d = private constant [3 x i8] c"%d\00", align 1');
         $this->addLine('@.str.f = private constant [6 x i8] c"%.14g\00", align 1');
         $this->addLine('@.str.s = private constant [3 x i8] c"%s\00", align 1');
+        $this->addLine('@.str.ss = private constant [5 x i8] c"%s%s\00", align 1');
         $this->addLine();
         $this->addLine('declare i32 @printf(ptr, ...)');
+        $this->addLine('declare i32 @snprintf(ptr, i64, ptr, ...)');
     }
 
     public function setInsertPoint(BasicBlock $bb): void
@@ -143,6 +145,17 @@ class Builder
             }
         }
         return $result;
+    }
+
+    protected int $concatCount = 0;
+
+    public function createStringConcat(ValueAbstract $left, ValueAbstract $right): ValueAbstract
+    {
+        $count = $this->concatCount++;
+        $buf = new AllocaInst("concat_buf{$count}", BaseType::PTR);
+        $this->addLine("{$buf->render()} = alloca [512 x i8]", 1);
+        $this->addLine("call i32 (ptr, i64, ptr, ...) @snprintf(ptr {$buf->render()}, i64 512, ptr @.str.ss, ptr {$left->render()}, ptr {$right->render()})", 1);
+        return $buf;
     }
 
     public function createCallPrintf(ValueAbstract $val): ValueAbstract

--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -274,6 +274,11 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
 
             $lval = $this->buildExpr($expr->left);
             $rval = $this->buildExpr($expr->right);
+
+            if ($sigil === '.') {
+                return $this->builder->createStringConcat($lval, $rval);
+            }
+
             $isFloat = $lval->getType() === BaseType::FLOAT;
             $operandType = $lval->getType();
             switch ($sigil) {

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -204,6 +204,9 @@ class SemanticAnalysisPass implements PassInterface
             $line = $this->getLine($expr);
             assert($ltype->isEqualTo($rtype), "line {$line}, type mismatch in binary op: {$ltype->toString()} {$expr->getOperatorSigil()} {$rtype->toString()}");
             switch ($expr->getOperatorSigil()) {
+                case '.':
+                    $type = PicoType::fromString('string');
+                    break;
                 case '+':
                 case '*':
                 case '-':

--- a/tests/Feature/StringConcatTest.php
+++ b/tests/Feature/StringConcatTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles string concatenation correctly', function () {
+    $file = 'tests/programs/operators/string_concat.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/operators/string_concat.php
+++ b/tests/programs/operators/string_concat.php
@@ -1,0 +1,14 @@
+<?php
+
+function test_concat(): int
+{
+    /** @var string */
+    $a = "Hello";
+    /** @var string */
+    $b = " World";
+    echo $a . $b;
+    echo "foo" . "bar";
+    return 0;
+}
+
+test_concat();


### PR DESCRIPTION
## Summary
- Add `.` (string concatenation) operator support
- Uses `snprintf` into a 512-byte stack buffer to join two strings at runtime
- Adds `snprintf` declaration and `%s%s` format string to LLVM module preamble
- SemanticAnalysisPass: `.` returns string type
- IRGenerationPass: delegates to `Builder::createStringConcat`

## Test plan
- [x] `tests/programs/operators/string_concat.php` — concatenates variables and literals, output matches PHP
- [x] PHPStan passes at level max
- [x] Pint passes
- [ ] CI passes

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)