### PR TITLE
feat: add nullable type support and null coalescing operator

### DIFF
--- a/app/PicoHP/LLVM/Builder.php
+++ b/app/PicoHP/LLVM/Builder.php
@@ -129,7 +129,7 @@ class Builder
         $escaped = $this->escapeStringForLLVM($value);
         $len = strlen($value) + 1; // +1 for null terminator
         $this->module->addLine(new IRLine("@{$name} = private constant [{$len} x i8] c\"{$escaped}\\00\", align 1"));
-        return new Global_($name, BaseType::PTR);
+        return new Global_($name, BaseType::STRING);
     }
 
     protected function escapeStringForLLVM(string $value): string
@@ -188,6 +188,21 @@ class Builder
         $arrayType = $var->getType();
         $resultVal = new Instruction('getelementptr', BaseType::PTR);
         $this->addLine("{$resultVal->render()} = getelementptr inbounds {$arrayType->toLLVM()}, ptr {$var->render()}, i64 0, {$dim->getType()->toLLVM()} {$dim->render()}", 1);
+        return $resultVal;
+    }
+
+    public function createNullCheck(ValueAbstract $val): ValueAbstract
+    {
+        $resultVal = new Instruction('null_check', BaseType::BOOL);
+        $this->addLine("{$resultVal->render()} = icmp eq ptr {$val->render()}, null", 1);
+        return $resultVal;
+    }
+
+    public function createSelect(ValueAbstract $cond, ValueAbstract $true, ValueAbstract $false): ValueAbstract
+    {
+        $type = $true->getType();
+        $resultVal = new Instruction('select', $type);
+        $this->addLine("{$resultVal->render()} = select i1 {$cond->render()}, {$type->toLLVM()} {$true->render()}, {$type->toLLVM()} {$false->render()}", 1);
         return $resultVal;
     }
 

--- a/app/PicoHP/LLVM/Value/NullConstant.php
+++ b/app/PicoHP/LLVM/Value/NullConstant.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\PicoHP\LLVM\Value;
+
+use App\PicoHP\BaseType;
+use App\PicoHP\LLVM\ValueAbstract;
+
+class NullConstant extends ValueAbstract
+{
+    public function __construct()
+    {
+        parent::__construct(BaseType::STRING);
+    }
+
+    public function render(): string
+    {
+        return 'null';
+    }
+}

--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -6,7 +6,7 @@ namespace App\PicoHP\Pass;
 
 use App\PicoHP\{BaseType};
 use App\PicoHP\LLVM\{Module, Builder, ValueAbstract, IRLine};
-use App\PicoHP\LLVM\Value\{Constant, Void_, Label, Param};
+use App\PicoHP\LLVM\Value\{Constant, Void_, Label, Param, NullConstant};
 use App\PicoHP\SymbolTable\PicoHPData;
 use Illuminate\Support\Collection;
 
@@ -87,6 +87,7 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                 $this->builder->createInstruction('ret', [$val], false);
             }
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Nop) {
+        } elseif ($stmt instanceof \PhpParser\Node\Stmt\Declare_) {
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Echo_) {
             foreach ($stmt->exprs as $expr) {
                 $val = $this->buildExpr($expr);
@@ -264,6 +265,11 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                 return $value;
             }
             return $this->builder->createLoad($value);
+        } elseif ($expr instanceof \PhpParser\Node\Expr\BinaryOp\Coalesce) {
+            $lval = $this->buildExpr($expr->left);
+            $rval = $this->buildExpr($expr->right);
+            $isNull = $this->builder->createNullCheck($lval);
+            return $this->builder->createSelect($isNull, $rval, $lval);
         } elseif ($expr instanceof \PhpParser\Node\Expr\BinaryOp) {
             $sigil = $expr->getOperatorSigil();
 
@@ -352,6 +358,9 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             return new Void_();
         } elseif ($expr instanceof \PhpParser\Node\Expr\ConstFetch) {
             $constName = $expr->name->toLowerString();
+            if ($constName === 'null') {
+                return new NullConstant();
+            }
             return new Constant($constName === 'true' ? 1 : 0, BaseType::BOOL);
         } elseif ($expr instanceof \PhpParser\Node\Expr\Cast\Int_) {
             $val = $this->buildExpr($expr->expr);

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -43,17 +43,26 @@ class SemanticAnalysisPass implements PassInterface
     {
         foreach ($stmts as $stmt) {
             if ($stmt instanceof \PhpParser\Node\Stmt\Function_) {
-                assert($stmt->returnType instanceof \PhpParser\Node\Identifier);
+                assert($stmt->returnType instanceof \PhpParser\Node\Identifier || $stmt->returnType instanceof \PhpParser\Node\NullableType);
                 $existing = $this->symbolTable->lookupCurrentScope($stmt->name->name);
                 if ($existing === null) {
                     $this->symbolTable->addSymbol(
                         $stmt->name->name,
-                        PicoType::fromString($stmt->returnType->name),
+                        $this->typeFromNode($stmt->returnType),
                         func: true
                     );
                 }
             }
         }
+    }
+
+    private function typeFromNode(\PhpParser\Node\Identifier|\PhpParser\Node\NullableType $node): PicoType
+    {
+        if ($node instanceof \PhpParser\Node\NullableType) {
+            assert($node->type instanceof \PhpParser\Node\Identifier);
+            return PicoType::fromString('?' . $node->type->name);
+        }
+        return PicoType::fromString($node->name);
     }
 
     /**
@@ -73,16 +82,17 @@ class SemanticAnalysisPass implements PassInterface
 
         if ($stmt instanceof \PhpParser\Node\Stmt\Function_) {
             assert(!is_null($stmt->returnType));
-            assert($stmt->returnType instanceof \PhpParser\Node\Identifier);
+            assert($stmt->returnType instanceof \PhpParser\Node\Identifier || $stmt->returnType instanceof \PhpParser\Node\NullableType);
+            $returnType = $this->typeFromNode($stmt->returnType);
             $existing = $this->symbolTable->lookupCurrentScope($stmt->name->name);
-            $pData->symbol = $existing ?? $this->symbolTable->addSymbol($stmt->name->name, PicoType::fromString($stmt->returnType->name), func: true);
+            $pData->symbol = $existing ?? $this->symbolTable->addSymbol($stmt->name->name, $returnType, func: true);
             if ($stmt->name->name !== 'main') {
                 $pData->setScope($this->symbolTable->enterScope());
             }
 
             $pData->getSymbol()->params = $this->resolveParams($stmt->params);
             $previousReturnType = $this->currentFunctionReturnType;
-            $this->currentFunctionReturnType = PicoType::fromString($stmt->returnType->name);
+            $this->currentFunctionReturnType = $returnType;
             $this->resolveStmts($stmt->stmts);
             $this->currentFunctionReturnType = $previousReturnType;
 
@@ -105,7 +115,7 @@ class SemanticAnalysisPass implements PassInterface
                 }
             }
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Nop) {
-
+        } elseif ($stmt instanceof \PhpParser\Node\Stmt\Declare_) {
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Echo_) {
             foreach ($stmt->exprs as $expr) {
                 $this->resolveExpr($expr);
@@ -139,7 +149,6 @@ class SemanticAnalysisPass implements PassInterface
             }
             $this->resolveStmts($stmt->stmts);
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Foreach_) {
-
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Class_) {
             $pData->setScope($this->symbolTable->enterScope());
             $this->resolveStmts($stmt->stmts);
@@ -198,6 +207,9 @@ class SemanticAnalysisPass implements PassInterface
             assert($dimType->isEqualTo(PicoType::fromString('int')), "{$dimType->toString()} is not an int");
             // if doc is null type will be from a retrieved value
             return PicoType::fromString('int'); // really a char/byte or maybe a single byte string?
+        } elseif ($expr instanceof \PhpParser\Node\Expr\BinaryOp\Coalesce) {
+            $this->resolveExpr($expr->left);
+            return $this->resolveExpr($expr->right);
         } elseif ($expr instanceof \PhpParser\Node\Expr\BinaryOp) {
             $ltype = $this->resolveExpr($expr->left);
             $rtype = $this->resolveExpr($expr->right);
@@ -230,6 +242,9 @@ class SemanticAnalysisPass implements PassInterface
                 case '||':
                     $type = PicoType::fromString('bool');
                     break;
+                case '??':
+                    $type = $rtype; // result is the fallback type
+                    break;
                 default:
                     throw new \Exception("unknown BinaryOp {$expr->getOperatorSigil()}");
             }
@@ -261,7 +276,10 @@ class SemanticAnalysisPass implements PassInterface
             $this->resolveExpr($expr->expr);
             return PicoType::fromString('float');
         } elseif ($expr instanceof \PhpParser\Node\Expr\ConstFetch) {
-            return PicoType::fromString('bool'); // TODO: ??
+            if ($expr->name->toLowerString() === 'null') {
+                return PicoType::fromString('string'); // null represented as ptr
+            }
+            return PicoType::fromString('bool');
         } elseif ($expr instanceof \PhpParser\Node\Expr\FuncCall) {
             $this->resolveArgs($expr->args);
             assert($expr->name instanceof \PhpParser\Node\Name);
@@ -315,9 +333,10 @@ class SemanticAnalysisPass implements PassInterface
             $pData = $this->getPicoData($param);
             assert($param->var instanceof \PhpParser\Node\Expr\Variable);
             assert(is_string($param->var->name));
-            assert($param->type instanceof \PhpParser\Node\Identifier);
-            $pData->symbol = $this->symbolTable->addSymbol($param->var->name, PicoType::fromString($param->type->name));
-            $paramTypes[] = PicoType::fromString($param->type->name);
+            assert($param->type instanceof \PhpParser\Node\Identifier || $param->type instanceof \PhpParser\Node\NullableType);
+            $paramType = $this->typeFromNode($param->type);
+            $pData->symbol = $this->symbolTable->addSymbol($param->var->name, $paramType);
+            $paramTypes[] = $paramType;
         }
         return $paramTypes;
     }

--- a/app/PicoHP/PicoType.php
+++ b/app/PicoHP/PicoType.php
@@ -25,18 +25,6 @@ enum BaseType: string
             default => 'i8*',
         };
     }
-
-    // thought about adding QBE (https://c9x.me/compile/) support
-    /* public function toQBE(): string
-    {
-        return match($this) {
-            BaseType::INT => 'w',
-            BaseType::FLOAT => 'd',
-            BaseType::BOOL => 'w',
-            BaseType::VOID => 'v',
-            default => 'l',
-        };
-    }*/
 }
 
 enum PicoTypeType
@@ -54,6 +42,7 @@ class PicoType
 
     protected PicoTypeType $typeType;
     protected BaseType $type;
+    protected bool $nullable = false;
 
     /**
      * @param array<BaseType> $params
@@ -78,11 +67,22 @@ class PicoType
 
     public static function fromString(string $type): PicoType
     {
+        if (str_starts_with($type, '?')) {
+            $inner = substr($type, 1);
+            $pt = new PicoType(BaseType::from($inner));
+            $pt->nullable = true;
+            return $pt;
+        }
         return new PicoType(BaseType::from($type));
+    }
+
+    public function isNullable(): bool
+    {
+        return $this->nullable;
     }
 
     public function toString(): string
     {
-        return $this->type->value;
+        return ($this->nullable ? '?' : '') . $this->type->value;
     }
 }

--- a/tests/Feature/NullableTest.php
+++ b/tests/Feature/NullableTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles nullable param with null coalescing', function () {
+    $file = 'tests/programs/nullable/nullable_param.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles null coalescing operator', function () {
+    $file = 'tests/programs/nullable/null_coalesce.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles null check with === null', function () {
+    $file = 'tests/programs/nullable/null_check.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles nullable return type', function () {
+    $file = 'tests/programs/nullable/nullable_return.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/nullable/null_check.php
+++ b/tests/programs/nullable/null_check.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+function describe(?string $val): string
+{
+    if ($val === null) {
+        return 'nothing';
+    }
+    return $val;
+}
+
+echo describe('something');
+echo "\n";
+echo describe(null);
+echo "\n";

--- a/tests/programs/nullable/null_coalesce.php
+++ b/tests/programs/nullable/null_coalesce.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+function first(?string $a, string $b): string
+{
+    return $a ?? $b;
+}
+
+echo first('foo', 'bar');
+echo "\n";
+echo first(null, 'bar');
+echo "\n";

--- a/tests/programs/nullable/nullable_param.php
+++ b/tests/programs/nullable/nullable_param.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+function greet(?string $name): string
+{
+    return 'hello ' . ($name ?? 'world');
+}
+
+echo greet('alice');
+echo "\n";
+echo greet(null);
+echo "\n";

--- a/tests/programs/nullable/nullable_return.php
+++ b/tests/programs/nullable/nullable_return.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+function maybeNull(bool $flag): ?string
+{
+    if ($flag) {
+        return 'yes';
+    }
+    return null;
+}
+
+$a = maybeNull(true);
+$b = maybeNull(false);
+echo $a ?? 'none';
+echo "\n";
+echo $b ?? 'none';
+echo "\n";


### PR DESCRIPTION
## Summary
- Support `?Type` syntax for function parameters and return types
- Add null constant, null coalescing operator (`??`), and null checks (`=== null`)
- Add `NullConstant` LLVM value, `createNullCheck()` and `createSelect()` builder methods
- Add `Declare_` statement handler

## Test plan
- [x] 4 new test programs: nullable_param, null_coalesce, null_check, nullable_return
- [x] All existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)