### PR TITLE
feat: add initial object/class support

### DIFF
--- a/app/Commands/Build.php
+++ b/app/Commands/Build.php
@@ -102,15 +102,15 @@ class Build extends Command
             // TODO: rerun static analysis on transformed output?
         }
 
-        $pass = new SemanticAnalysisPass($transformedAst);
-        $pass->exec();
+        $semanticPass = new SemanticAnalysisPass($transformedAst);
+        $semanticPass->exec();
 
         if ($debug) {
             $astWithSymbolOutput = "{$buildPath}/ast_sym.json";
             file_put_contents($astWithSymbolOutput, json_encode($transformedAst, JSON_PRETTY_PRINT));
         }
 
-        $pass = new IRGenerationPass($transformedAst);
+        $pass = new IRGenerationPass($transformedAst, $semanticPass->getClassRegistry());
         $pass->exec();
 
         $f = fopen($llvmIRoutput, 'w');

--- a/app/PicoHP/LLVM/Builder.php
+++ b/app/PicoHP/LLVM/Builder.php
@@ -31,6 +31,7 @@ class Builder
         $this->addLine('declare i32 @printf(ptr, ...)');
         $this->addLine('declare ptr @pico_string_concat(ptr, ptr)');
         $this->addLine('declare i32 @pico_rt_version()');
+        $this->addLine('declare ptr @malloc(i64)');
         $this->addLine();
         $this->addLine('; array runtime');
         $this->addLine('declare ptr @pico_array_new()');
@@ -204,6 +205,24 @@ class Builder
         $arrayType = $var->getType();
         $resultVal = new Instruction('getelementptr', BaseType::PTR);
         $this->addLine("{$resultVal->render()} = getelementptr inbounds {$arrayType->toLLVM()}, ptr {$var->render()}, i64 0, {$dim->getType()->toLLVM()} {$dim->render()}", 1);
+        return $resultVal;
+    }
+
+    // -- object support ------------------------------------------------------
+
+    public function createMalloc(string $structName): ValueAbstract
+    {
+        $sizeVal = new Instruction('sizeof', BaseType::INT);
+        $this->addLine("{$sizeVal->render()} = ptrtoint ptr getelementptr (%struct.{$structName}, ptr null, i32 1) to i64", 1);
+        $resultVal = new Instruction('malloc', BaseType::PTR);
+        $this->addLine("{$resultVal->render()} = call ptr @malloc(i64 {$sizeVal->render()})", 1);
+        return $resultVal;
+    }
+
+    public function createStructGEP(string $structName, ValueAbstract $ptr, int $fieldIndex, BaseType $fieldType): ValueAbstract
+    {
+        $resultVal = new Instruction("gep_field{$fieldIndex}", $fieldType);
+        $this->addLine("{$resultVal->render()} = getelementptr inbounds %struct.{$structName}, ptr {$ptr->render()}, i32 0, i32 {$fieldIndex}", 1);
         return $resultVal;
     }
 

--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -7,7 +7,7 @@ namespace App\PicoHP\Pass;
 use App\PicoHP\{BaseType};
 use App\PicoHP\LLVM\{Module, Builder, ValueAbstract, IRLine};
 use App\PicoHP\LLVM\Value\{Constant, Void_, Label, Param, NullConstant};
-use App\PicoHP\SymbolTable\PicoHPData;
+use App\PicoHP\SymbolTable\{ClassMetadata, PicoHPData};
 use Illuminate\Support\Collection;
 
 class IRGenerationPass implements \App\PicoHP\PassInterface
@@ -15,20 +15,26 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
     public Module $module;
     protected Builder $builder;
     protected ?\App\PicoHP\LLVM\Function_ $currentFunction = null;
+    protected ?string $currentClassName = null;
 
     /**
      * @var array<\PhpParser\Node> $stmts
      */
     protected array $stmts;
 
+    /** @var array<string, ClassMetadata> */
+    protected array $classRegistry = [];
+
     /**
      * @param array<\PhpParser\Node> $stmts
+     * @param array<string, ClassMetadata> $classRegistry
      */
-    public function __construct(array $stmts)
+    public function __construct(array $stmts, array $classRegistry = [])
     {
         $this->module = new Module("test_module");
         $this->builder = $this->module->getBuilder();
         $this->stmts = $stmts;
+        $this->classRegistry = $classRegistry;
     }
 
     public function exec(): void
@@ -188,16 +194,52 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             $this->builder->createBranch([$condLabel]);
             $this->builder->setInsertPoint($endBB);
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Class_) {
-            // TODO: generate struct type
             assert($stmt->name instanceof \PhpParser\Node\Identifier);
             $className = $stmt->name->toString();
-            $this->module->addLine(new IRLine("%struct.$className = type {"));
+            assert(isset($this->classRegistry[$className]));
+            $classMeta = $this->classRegistry[$className];
+            $fields = $classMeta->toLLVMStructFields();
+            $this->module->addLine(new IRLine("%struct.{$className} = type { {$fields} }"));
+            $this->currentClassName = $className;
             $this->buildStmts($stmt->stmts);
-            $this->module->addLine(new IRLine("}"));
+            $this->currentClassName = null;
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Property) {
-            dump($pData);
-            // this is dumb just join the types
-            $this->module->addLine(new IRLine("i32"));
+            // Handled by struct type definition
+        } elseif ($stmt instanceof \PhpParser\Node\Stmt\ClassMethod) {
+            assert($this->currentClassName !== null);
+            $methodName = $stmt->name->toString();
+            $funcSymbol = $pData->getSymbol();
+            $qualifiedName = "{$this->currentClassName}_{$methodName}";
+            // Methods get $this (ptr) as first param
+            $thisParam = new \App\PicoHP\PicoType(\App\PicoHP\BaseType::PTR);
+            $allParams = array_merge([$thisParam], $funcSymbol->params);
+            $this->currentFunction = $this->module->addFunction($qualifiedName, $funcSymbol->type, $allParams);
+            $bb = $this->currentFunction->addBasicBlock("entry");
+            $this->builder->setInsertPoint($bb);
+            $scope = $pData->getScope();
+            foreach ($scope->symbols as $symbol) {
+                if ($symbol->func) {
+                    continue;
+                }
+                $symbol->value = $this->buildSymbolAlloca($symbol);
+            }
+            // Store $this param (param 0) into its alloca
+            $thisSymbol = $scope->symbols['this'] ?? null;
+            assert($thisSymbol !== null);
+            assert($thisSymbol->value !== null);
+            $this->builder->createStore(new Param(0, \App\PicoHP\BaseType::PTR), $thisSymbol->value);
+            // Store remaining params (offset by 1)
+            $paramIndex = 1;
+            foreach ($stmt->params as $param) {
+                $paramPData = PicoHPData::getPData($param);
+                $type = $paramPData->getSymbol()->type;
+                $this->builder->createStore(new Param($paramIndex++, $type->toBase()), $paramPData->getValue());
+            }
+            assert($stmt->stmts !== null);
+            $this->buildStmts($stmt->stmts);
+            if ($funcSymbol->type->toBase() === \App\PicoHP\BaseType::VOID) {
+                $this->builder->createRetVoid();
+            }
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Do_) {
             assert($this->currentFunction !== null);
             $condBB = $this->currentFunction->addBasicBlock("cond{$pData->mycount}");
@@ -526,9 +568,68 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             $newVal = $this->builder->createInstruction('sub', [$oldVal, new Constant(1, $oldVal->getType())]);
             $this->builder->createStore($newVal, $ptr);
             return $newVal;
+        } elseif ($expr instanceof \PhpParser\Node\Expr\New_) {
+            assert($expr->class instanceof \PhpParser\Node\Name);
+            $className = $expr->class->toString();
+            $classMeta = $this->classRegistry[$className];
+            $objPtr = $this->builder->createMalloc($className);
+            // Call constructor if it exists
+            if (isset($classMeta->methods['__construct'])) {
+                $args = (new Collection($expr->args))
+                    ->map(function ($arg): ValueAbstract {
+                        assert($arg instanceof \PhpParser\Node\Arg);
+                        return $this->buildExpr($arg->value);
+                    })
+                    ->toArray();
+                /** @var array<ValueAbstract> $allArgs */
+                $allArgs = array_merge([$objPtr], $args);
+                $qualifiedName = "{$className}___construct";
+                $this->builder->createCall($qualifiedName, $allArgs, BaseType::VOID);
+            }
+            return $objPtr;
+        } elseif ($expr instanceof \PhpParser\Node\Expr\PropertyFetch) {
+            assert($expr->name instanceof \PhpParser\Node\Identifier);
+            $objVal = $this->buildExpr($expr->var);
+            $objType = PicoHPData::getPData($expr->var);
+            // Determine class name from the variable's symbol type
+            $varType = $this->getExprType($expr->var);
+            $className = $varType->getClassName();
+            $classMeta = $this->classRegistry[$className];
+            $propName = $expr->name->toString();
+            $fieldIndex = $classMeta->getPropertyIndex($propName);
+            $fieldType = $classMeta->getPropertyType($propName)->toBase();
+            $fieldPtr = $this->builder->createStructGEP($className, $objVal, $fieldIndex, $fieldType);
+            if ($pData->lVal) {
+                return $fieldPtr;
+            }
+            return $this->builder->createLoad($fieldPtr);
+        } elseif ($expr instanceof \PhpParser\Node\Expr\MethodCall) {
+            assert($expr->name instanceof \PhpParser\Node\Identifier);
+            $objVal = $this->buildExpr($expr->var);
+            $varType = $this->getExprType($expr->var);
+            $className = $varType->getClassName();
+            $classMeta = $this->classRegistry[$className];
+            $methodName = $expr->name->toString();
+            $methodSymbol = $classMeta->methods[$methodName];
+            $args = (new Collection($expr->args))
+                ->map(function ($arg): ValueAbstract {
+                    assert($arg instanceof \PhpParser\Node\Arg);
+                    return $this->buildExpr($arg->value);
+                })
+                ->toArray();
+            /** @var array<ValueAbstract> $allArgs */
+            $allArgs = array_merge([$objVal], $args);
+            $qualifiedName = "{$className}_{$methodName}";
+            return $this->builder->createCall($qualifiedName, $allArgs, $methodSymbol->type->toBase());
         } else {
             throw new \Exception("unknown node type in expr: " . get_class($expr));
         }
+    }
+
+    protected function getExprType(\PhpParser\Node\Expr $expr): \App\PicoHP\PicoType
+    {
+        $pData = PicoHPData::getPData($expr);
+        return $pData->getSymbol()->type;
     }
 
     protected function buildShortCircuit(\PhpParser\Node\Expr\BinaryOp $expr, PicoHPData $pData): ValueAbstract

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -3,7 +3,7 @@
 namespace App\PicoHP\Pass;
 
 use App\PicoHP\{PassInterface, SymbolTable};
-use App\PicoHP\SymbolTable\{DocTypeParser, PicoHPData};
+use App\PicoHP\SymbolTable\{ClassMetadata, DocTypeParser, PicoHPData};
 use App\PicoHP\{BaseType, PicoType};
 
 class SemanticAnalysisPass implements PassInterface
@@ -16,6 +16,10 @@ class SemanticAnalysisPass implements PassInterface
     protected SymbolTable $symbolTable;
     protected DocTypeParser $docTypeParser;
     protected ?PicoType $currentFunctionReturnType = null;
+    protected ?ClassMetadata $currentClass = null;
+
+    /** @var array<string, ClassMetadata> */
+    protected array $classRegistry = [];
 
     /**
      * @param array<\PhpParser\Node> $ast
@@ -27,10 +31,63 @@ class SemanticAnalysisPass implements PassInterface
         $this->docTypeParser = new DocTypeParser();
     }
 
+    public function getClassMetadata(string $name): ClassMetadata
+    {
+        assert(isset($this->classRegistry[$name]), "class {$name} not found");
+        return $this->classRegistry[$name];
+    }
+
+    /**
+     * @return array<string, ClassMetadata>
+     */
+    public function getClassRegistry(): array
+    {
+        return $this->classRegistry;
+    }
+
     public function exec(): void
     {
+        $this->registerClasses($this->ast);
         $this->registerFunctions($this->ast);
         $this->resolveStmts($this->ast);
+    }
+
+    /**
+     * Pre-pass: register class metadata (properties and method signatures).
+     *
+     * @param array<\PhpParser\Node> $stmts
+     */
+    protected function registerClasses(array $stmts): void
+    {
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof \PhpParser\Node\Stmt\Namespace_) {
+                $this->registerClasses($stmt->stmts);
+                continue;
+            }
+            if ($stmt instanceof \PhpParser\Node\Stmt\Class_) {
+                assert($stmt->name instanceof \PhpParser\Node\Identifier);
+                $className = $stmt->name->toString();
+                $classMeta = new ClassMetadata($className);
+                $this->classRegistry[$className] = $classMeta;
+                foreach ($stmt->stmts as $classStmt) {
+                    if ($classStmt instanceof \PhpParser\Node\Stmt\Property) {
+                        assert($classStmt->type instanceof \PhpParser\Node\Identifier || $classStmt->type instanceof \PhpParser\Node\NullableType);
+                        $propType = $this->typeFromNode($classStmt->type);
+                        foreach ($classStmt->props as $prop) {
+                            $classMeta->addProperty($prop->name->toString(), $propType);
+                        }
+                    } elseif ($classStmt instanceof \PhpParser\Node\Stmt\ClassMethod) {
+                        $methodName = $classStmt->name->toString();
+                        assert($classStmt->returnType === null || $classStmt->returnType instanceof \PhpParser\Node\Identifier || $classStmt->returnType instanceof \PhpParser\Node\NullableType);
+                        $returnType = $classStmt->returnType !== null
+                            ? $this->typeFromNode($classStmt->returnType)
+                            : PicoType::fromString('void');
+                        $methodSymbol = new \App\PicoHP\SymbolTable\Symbol($methodName, $returnType, func: true);
+                        $classMeta->methods[$methodName] = $methodSymbol;
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -161,14 +218,43 @@ class SemanticAnalysisPass implements PassInterface
             // TODO: key var support
             $this->resolveStmts($stmt->stmts);
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Class_) {
+            assert($stmt->name instanceof \PhpParser\Node\Identifier);
+            $className = $stmt->name->toString();
+            $classMeta = $this->classRegistry[$className] ?? null;
+            if ($classMeta === null) {
+                // Class not pre-registered (e.g., only has static methods handled by ClassToFunctionVisitor)
+                $classMeta = new ClassMetadata($className);
+                $this->classRegistry[$className] = $classMeta;
+            }
+            $previousClass = $this->currentClass;
+            $this->currentClass = $classMeta;
             $pData->setScope($this->symbolTable->enterScope());
+            // Add $this to the class scope
+            $this->symbolTable->addSymbol('this', PicoType::object($className));
+            // Resolve methods (properties already registered in registerClasses)
             $this->resolveStmts($stmt->stmts);
             $this->symbolTable->exitScope();
+            $this->currentClass = $previousClass;
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Property) {
-            assert($stmt->type instanceof \PhpParser\Node\Identifier);
-            foreach ($stmt->props as $prop) {
-                $this->resolveProperty($prop, $pData, PicoType::fromString($stmt->type->name));
-            }
+            // Properties already registered in Class_ handler
+        } elseif ($stmt instanceof \PhpParser\Node\Stmt\ClassMethod) {
+            assert($this->currentClass !== null);
+            $methodName = $stmt->name->toString();
+            assert($stmt->returnType instanceof \PhpParser\Node\Identifier || $stmt->returnType instanceof \PhpParser\Node\NullableType || $stmt->returnType === null);
+            $returnType = $stmt->returnType !== null ? $this->typeFromNode($stmt->returnType) : PicoType::fromString('void');
+            $methodSymbol = $this->symbolTable->addSymbol($methodName, $returnType, func: true);
+            $pData->symbol = $methodSymbol;
+            $this->currentClass->methods[$methodName] = $methodSymbol;
+            $pData->setScope($this->symbolTable->enterScope());
+            // Add $this to method scope
+            $this->symbolTable->addSymbol('this', PicoType::object($this->currentClass->name));
+            $methodSymbol->params = $this->resolveParams($stmt->params);
+            $previousReturnType = $this->currentFunctionReturnType;
+            $this->currentFunctionReturnType = $returnType;
+            assert($stmt->stmts !== null);
+            $this->resolveStmts($stmt->stmts);
+            $this->currentFunctionReturnType = $previousReturnType;
+            $this->symbolTable->exitScope();
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Interface_) {
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Namespace_) {
             $this->resolveStmts($stmt->stmts);
@@ -331,6 +417,29 @@ class SemanticAnalysisPass implements PassInterface
                 }
             }
             return PicoType::array($elementType);
+        } elseif ($expr instanceof \PhpParser\Node\Expr\New_) {
+            assert($expr->class instanceof \PhpParser\Node\Name);
+            $className = $expr->class->toString();
+            assert(isset($this->classRegistry[$className]), "class {$className} not found");
+            $this->resolveArgs($expr->args);
+            return PicoType::object($className);
+        } elseif ($expr instanceof \PhpParser\Node\Expr\PropertyFetch) {
+            $pData->lVal = $lVal;
+            $objType = $this->resolveExpr($expr->var);
+            assert($objType->isObject(), "property fetch on non-object type: {$objType->toString()}");
+            assert($expr->name instanceof \PhpParser\Node\Identifier);
+            $classMeta = $this->classRegistry[$objType->getClassName()];
+            return $classMeta->getPropertyType($expr->name->toString());
+        } elseif ($expr instanceof \PhpParser\Node\Expr\MethodCall) {
+            $objType = $this->resolveExpr($expr->var);
+            assert($objType->isObject(), "method call on non-object type: {$objType->toString()}");
+            assert($expr->name instanceof \PhpParser\Node\Identifier);
+            $className = $objType->getClassName();
+            $methodName = $expr->name->toString();
+            $classMeta = $this->classRegistry[$className];
+            assert(isset($classMeta->methods[$methodName]), "method {$methodName} not found on class {$className}");
+            $this->resolveArgs($expr->args);
+            return $classMeta->methods[$methodName]->type;
         } else {
             $line = $this->getLine($expr);
             throw new \Exception("line {$line}, unknown node type in expr resolver: " . get_class($expr));

--- a/app/PicoHP/PicoType.php
+++ b/app/PicoHP/PicoType.php
@@ -48,6 +48,9 @@ class PicoType
     protected bool $isArray = false;
     protected ?BaseType $elementType = null;
 
+    // Class/object support
+    protected ?string $className = null;
+
     /**
      * @param array<BaseType> $params
      */
@@ -80,7 +83,12 @@ class PicoType
         if (preg_match('/^array<[^,]+,\s*(\w+)>$/', $type, $m) === 1) {
             return self::array(BaseType::from($m[1]));
         }
-        return new PicoType(BaseType::from($type));
+        $baseType = BaseType::tryFrom($type);
+        if ($baseType !== null) {
+            return new PicoType($baseType);
+        }
+        // Assume it's a class name
+        return self::object($type);
     }
 
     public static function array(BaseType $elementType): PicoType
@@ -89,6 +97,24 @@ class PicoType
         $pt->isArray = true;
         $pt->elementType = $elementType;
         return $pt;
+    }
+
+    public static function object(string $className): PicoType
+    {
+        $pt = new PicoType(BaseType::PTR);
+        $pt->className = $className;
+        return $pt;
+    }
+
+    public function isObject(): bool
+    {
+        return $this->className !== null;
+    }
+
+    public function getClassName(): string
+    {
+        assert($this->className !== null, 'getClassName() called on non-object PicoType');
+        return $this->className;
     }
 
     public function isNullable(): bool

--- a/app/PicoHP/SymbolTable/ClassMetadata.php
+++ b/app/PicoHP/SymbolTable/ClassMetadata.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\PicoHP\SymbolTable;
+
+use App\PicoHP\PicoType;
+
+class ClassMetadata
+{
+    public string $name;
+
+    /** @var array<string, PicoType> property name => type */
+    public array $properties = [];
+
+    /** @var array<string, int> property name => struct field index */
+    public array $propertyOffsets = [];
+
+    /** @var array<string, Symbol> method name => symbol (with params/return type) */
+    public array $methods = [];
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function addProperty(string $name, PicoType $type): int
+    {
+        $index = count($this->properties);
+        $this->properties[$name] = $type;
+        $this->propertyOffsets[$name] = $index;
+        return $index;
+    }
+
+    public function getPropertyIndex(string $name): int
+    {
+        assert(isset($this->propertyOffsets[$name]), "property {$name} not found on class {$this->name}");
+        return $this->propertyOffsets[$name];
+    }
+
+    public function getPropertyType(string $name): PicoType
+    {
+        assert(isset($this->properties[$name]), "property {$name} not found on class {$this->name}");
+        return $this->properties[$name];
+    }
+
+    /**
+     * Returns the LLVM struct field types string for the type definition.
+     * e.g., "i32, double, ptr" for a class with int, float, string properties.
+     */
+    public function toLLVMStructFields(): string
+    {
+        $fields = [];
+        foreach ($this->properties as $type) {
+            $fields[] = $type->toBase()->toLLVM();
+        }
+        return implode(', ', $fields);
+    }
+}

--- a/tests/Feature/ClassTest.php
+++ b/tests/Feature/ClassTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles basic class with properties and methods', function () {
+    $file = 'tests/programs/classes/basic_class.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/classes/basic_class.php
+++ b/tests/programs/classes/basic_class.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+class Point
+{
+    public int $x;
+    public int $y;
+
+    public function __construct(int $x, int $y)
+    {
+        $this->x = $x;
+        $this->y = $y;
+    }
+
+    public function sum(): int
+    {
+        return $this->x + $this->y;
+    }
+}
+
+$p = new Point(3, 7);
+echo $p->x;
+echo "\n";
+echo $p->y;
+echo "\n";
+echo $p->sum();
+echo "\n";


### PR DESCRIPTION
## Summary
- Classes with typed properties, constructors, and methods
- Objects heap-allocated via `malloc` with compile-time struct layout
- Property access via `getelementptr` with known field offsets
- Methods emitted as functions with `$this` (ptr) as first parameter
- Direct dispatch only (no vtables) — all types known at compile time
- `PicoType::object('ClassName')` for class type tracking
- `ClassMetadata` stores property offsets, types, and method signatures
- Pre-registration of classes handles forward references

## What works
```php
class Point {
    public int $x;
    public int $y;
    public function __construct(int $x, int $y) { $this->x = $x; $this->y = $y; }
    public function sum(): int { return $this->x + $this->y; }
}
$p = new Point(3, 7);
echo $p->x;    // 3
echo $p->sum(); // 10
```

## Not yet supported
- Inheritance (`extends`)
- Interfaces / abstract classes / vtable dispatch
- `instanceof`
- Refcounting / memory management
- Constructor promotion
- Visibility modifiers

Partial #65

## Test plan
- [x] `basic_class.php` — constructor, property access, method call
- [x] All 60 existing tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)