### PR TITLE
feat: route allocation through runtime, add count() and strlen()

### DIFF
--- a/app/PicoHP/LLVM/Builder.php
+++ b/app/PicoHP/LLVM/Builder.php
@@ -31,7 +31,8 @@ class Builder
         $this->addLine('declare i32 @printf(ptr, ...)');
         $this->addLine('declare ptr @pico_string_concat(ptr, ptr)');
         $this->addLine('declare i32 @pico_rt_version()');
-        $this->addLine('declare ptr @malloc(i64)');
+        $this->addLine('declare i32 @pico_string_len(ptr)');
+        $this->addLine('declare ptr @picohp_object_alloc(i64, i32)');
         $this->addLine();
         $this->addLine('; array runtime');
         $this->addLine('declare ptr @pico_array_new()');
@@ -210,12 +211,19 @@ class Builder
 
     // -- object support ------------------------------------------------------
 
-    public function createMalloc(string $structName): ValueAbstract
+    public function createObjectAlloc(string $structName, int $typeId = 0): ValueAbstract
     {
         $sizeVal = new Instruction('sizeof', BaseType::INT);
         $this->addLine("{$sizeVal->render()} = ptrtoint ptr getelementptr (%struct.{$structName}, ptr null, i32 1) to i64", 1);
-        $resultVal = new Instruction('malloc', BaseType::PTR);
-        $this->addLine("{$resultVal->render()} = call ptr @malloc(i64 {$sizeVal->render()})", 1);
+        $resultVal = new Instruction('alloc', BaseType::PTR);
+        $this->addLine("{$resultVal->render()} = call ptr @picohp_object_alloc(i64 {$sizeVal->render()}, i32 {$typeId})", 1);
+        return $resultVal;
+    }
+
+    public function createStringLen(ValueAbstract $str): ValueAbstract
+    {
+        $resultVal = new Instruction('strlen', BaseType::INT);
+        $this->addLine("{$resultVal->render()} = call i32 @pico_string_len(ptr {$str->render()})", 1);
         return $resultVal;
     }
 

--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -500,13 +500,27 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                     throw new \Exception("casting to float from unknown type");
             }
         } elseif ($expr instanceof \PhpParser\Node\Expr\FuncCall) {
+            assert($expr->name instanceof \PhpParser\Node\Name);
+            $funcName = $expr->name->toLowerString();
+            // Built-in functions
+            if ($funcName === 'count') {
+                assert(count($expr->args) === 1);
+                assert($expr->args[0] instanceof \PhpParser\Node\Arg);
+                $arrVal = $this->buildExpr($expr->args[0]->value);
+                return $this->builder->createArrayLen($arrVal);
+            }
+            if ($funcName === 'strlen') {
+                assert(count($expr->args) === 1);
+                assert($expr->args[0] instanceof \PhpParser\Node\Arg);
+                $strVal = $this->buildExpr($expr->args[0]->value);
+                return $this->builder->createStringLen($strVal);
+            }
             $args = (new Collection($expr->args))
                 ->map(function ($arg): ValueAbstract {
                     assert($arg instanceof \PhpParser\Node\Arg);
                     return $this->buildExpr($arg->value);
                 })
                 ->toArray();
-            assert($expr->name instanceof \PhpParser\Node\Name);
             $funcSymbol = $pData->getSymbol();
             $returnType = $funcSymbol->type->toBase();
             /** @phpstan-ignore-next-line */
@@ -572,7 +586,7 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             assert($expr->class instanceof \PhpParser\Node\Name);
             $className = $expr->class->toString();
             $classMeta = $this->classRegistry[$className];
-            $objPtr = $this->builder->createMalloc($className);
+            $objPtr = $this->builder->createObjectAlloc($className);
             // Call constructor if it exists
             if (isset($classMeta->methods['__construct'])) {
                 $args = (new Collection($expr->args))

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -387,6 +387,11 @@ class SemanticAnalysisPass implements PassInterface
         } elseif ($expr instanceof \PhpParser\Node\Expr\FuncCall) {
             $this->resolveArgs($expr->args);
             assert($expr->name instanceof \PhpParser\Node\Name);
+            $funcName = $expr->name->toLowerString();
+            // Built-in functions
+            if ($funcName === 'count' || $funcName === 'strlen') {
+                return PicoType::fromString('int');
+            }
             $s = $this->symbolTable->lookup($expr->name->name);
             $line = $this->getLine($expr);
             assert($s !== null, "line {$line}, function {$expr->name->name} not found");

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -24,6 +24,28 @@ pub extern "C" fn pico_string_concat(a: *const c_char, b: *const c_char) -> *mut
 }
 
 // ---------------------------------------------------------------------------
+// Strings
+// ---------------------------------------------------------------------------
+
+#[no_mangle]
+pub extern "C" fn pico_string_len(s: *const c_char) -> i32 {
+    let s = unsafe { CStr::from_ptr(s) };
+    s.to_bytes().len() as i32
+}
+
+// ---------------------------------------------------------------------------
+// Object allocation
+// ---------------------------------------------------------------------------
+
+/// Allocate `size` bytes for an object. The `type_id` is reserved for
+/// future use (refcounting, GC metadata).
+#[no_mangle]
+pub extern "C" fn picohp_object_alloc(size: u64, _type_id: u32) -> *mut u8 {
+    let layout = std::alloc::Layout::from_size_align(size as usize, 8).unwrap();
+    unsafe { std::alloc::alloc_zeroed(layout) }
+}
+
+// ---------------------------------------------------------------------------
 // Dynamic arrays
 // ---------------------------------------------------------------------------
 
@@ -144,6 +166,25 @@ pub extern "C" fn pico_array_set_str(arr: *mut PicoArray, index: i32, val: *cons
 mod tests {
     use super::*;
     use std::ffi::CString;
+
+    #[test]
+    fn test_string_len() {
+        let s = CString::new("hello").unwrap();
+        assert_eq!(pico_string_len(s.as_ptr()), 5);
+        let empty = CString::new("").unwrap();
+        assert_eq!(pico_string_len(empty.as_ptr()), 0);
+    }
+
+    #[test]
+    fn test_object_alloc() {
+        let ptr = picohp_object_alloc(16, 0);
+        assert!(!ptr.is_null());
+        // Verify zeroed
+        unsafe {
+            assert_eq!(*ptr, 0);
+            assert_eq!(*ptr.add(15), 0);
+        }
+    }
 
     #[test]
     fn test_version() {

--- a/tests/Feature/BuiltinFunctionTest.php
+++ b/tests/Feature/BuiltinFunctionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles count() on arrays', function () {
+    $file = 'tests/programs/functions/builtin_count.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles strlen() on strings', function () {
+    $file = 'tests/programs/functions/builtin_strlen.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/functions/builtin_count.php
+++ b/tests/programs/functions/builtin_count.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var array<int, string> */
+$names = ['alice', 'bob', 'charlie'];
+
+echo count($names);
+echo "\n";
+
+$names[] = 'dave';
+
+echo count($names);
+echo "\n";

--- a/tests/programs/functions/builtin_strlen.php
+++ b/tests/programs/functions/builtin_strlen.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+echo strlen('hello');
+echo "\n";
+echo strlen('');
+echo "\n";
+echo strlen('hello world');
+echo "\n";


### PR DESCRIPTION
## Summary
- Replace direct `malloc` call with `picohp_object_alloc(size, type_id)` runtime function (zeroed allocation, ready for future refcount/GC)
- Add `pico_string_len` runtime function
- Wire up `count()` and `strlen()` as built-in PHP functions recognized by the compiler
- Built-ins bypass the symbol table lookup and emit direct runtime calls

Closes #68, partial #69

## Test plan
- [x] `builtin_count.php` — count on array, count after push
- [x] `builtin_strlen.php` — strlen on various strings
- [x] All 62 tests pass, no regressions
- [x] 13 Rust runtime tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)