### PR TITLE
feat: support array-typed class properties

### DIFF
--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -286,13 +286,9 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             assert($this->currentFunction !== null);
             $count = $pData->mycount;
 
-            // Load array pointer from its alloca
-            $arrayVarPData = PicoHPData::getPData($stmt->expr);
-            $arraySymbol = $arrayVarPData->getSymbol();
-            $arrayType = $arraySymbol->type;
-            $arrayAllocaPtr = $arraySymbol->value;
-            assert($arrayAllocaPtr !== null);
-            $arrayPtr = $this->builder->createLoad($arrayAllocaPtr);
+            // Load array pointer (works for variables, property fetches, etc.)
+            $arrayPtr = $this->buildExpr($stmt->expr);
+            $arrayType = $this->getExprResolvedType($stmt->expr);
 
             assert($stmt->valueVar instanceof \PhpParser\Node\Expr\Variable);
             $valueVarPData = PicoHPData::getPData($stmt->valueVar);
@@ -343,8 +339,7 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             // Array literal: $arr = [1, 2, 3]
             if ($expr->expr instanceof \PhpParser\Node\Expr\Array_) {
                 $lval = $this->buildExpr($expr->var);
-                $varPData = PicoHPData::getPData($expr->var);
-                $arrayType = $varPData->getSymbol()->type;
+                $arrayType = $this->getExprResolvedType($expr->var);
                 $arrPtr = $this->buildArrayInit($expr->expr, $arrayType);
                 $this->builder->createStore($arrPtr, $lval);
                 return $arrPtr;
@@ -352,10 +347,11 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             // Array element write: $arr[idx] = val or $arr[] = val
             if ($expr->var instanceof \PhpParser\Node\Expr\ArrayDimFetch) {
                 $rval = $this->buildExpr($expr->expr);
-                $arrVarPData = PicoHPData::getPData($expr->var->var);
-                $arrAllocaPtr = $arrVarPData->getValue();
-                $arrPtr = $this->builder->createLoad($arrAllocaPtr);
-                $arrayType = $arrVarPData->getSymbol()->type;
+                // buildExpr in lVal context returns a pointer TO the array ptr — load it
+                $arrVarExpr = $expr->var->var;
+                $arrPtrPtr = $this->buildExpr($arrVarExpr);
+                $arrPtr = $this->builder->createLoad($arrPtrPtr);
+                $arrayType = $this->getExprResolvedType($arrVarExpr);
                 if ($expr->var->dim === null) {
                     // $arr[] = val (push)
                     $this->builder->createArrayPush($arrPtr, $rval, $arrayType->getElementBaseType());
@@ -526,15 +522,15 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             /** @phpstan-ignore-next-line */
             return $this->builder->createCall($expr->name->name, $args, $returnType);
         } elseif ($expr instanceof \PhpParser\Node\Expr\ArrayDimFetch) {
-            $varData = PicoHPData::getPData($expr->var);
-            $varType = $varData->getSymbol()->type;
+            $varType = $this->getExprResolvedType($expr->var);
             if ($varType->isArray()) {
                 // Array read: $arr[$idx] — writes handled in Assign
                 assert($expr->dim !== null, "array read requires index");
-                $arrPtr = $this->builder->createLoad($varData->getValue());
+                $arrPtr = $this->buildExpr($expr->var);
                 $idx = $this->buildExpr($expr->dim);
                 return $this->builder->createArrayGet($arrPtr, $idx, $varType->getElementBaseType());
             }
+            $varData = PicoHPData::getPData($expr->var);
             // String indexing (existing behavior)
             assert($expr->dim !== null);
             if ($pData->lVal === true) {
@@ -644,6 +640,20 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
     {
         $pData = PicoHPData::getPData($expr);
         return $pData->getSymbol()->type;
+    }
+
+    protected function getExprResolvedType(\PhpParser\Node\Expr $expr): \App\PicoHP\PicoType
+    {
+        if ($expr instanceof \PhpParser\Node\Expr\Variable) {
+            return PicoHPData::getPData($expr)->getSymbol()->type;
+        }
+        if ($expr instanceof \PhpParser\Node\Expr\PropertyFetch) {
+            assert($expr->name instanceof \PhpParser\Node\Identifier);
+            $objType = $this->getExprResolvedType($expr->var);
+            $classMeta = $this->classRegistry[$objType->getClassName()];
+            return $classMeta->getPropertyType($expr->name->toString());
+        }
+        throw new \RuntimeException('getExprResolvedType: unsupported expr type ' . get_class($expr));
     }
 
     protected function buildShortCircuit(\PhpParser\Node\Expr\BinaryOp $expr, PicoHPData $pData): ValueAbstract

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -72,7 +72,13 @@ class SemanticAnalysisPass implements PassInterface
                 foreach ($stmt->stmts as $classStmt) {
                     if ($classStmt instanceof \PhpParser\Node\Stmt\Property) {
                         assert($classStmt->type instanceof \PhpParser\Node\Identifier || $classStmt->type instanceof \PhpParser\Node\NullableType);
-                        $propType = $this->typeFromNode($classStmt->type);
+                        // Use PHPDoc annotation if available (for generic types like array<int, string>)
+                        $doc = $classStmt->getDocComment();
+                        if ($doc !== null) {
+                            $propType = $this->docTypeParser->parseType($doc->getText());
+                        } else {
+                            $propType = $this->typeFromNode($classStmt->type);
+                        }
                         foreach ($classStmt->props as $prop) {
                             $classMeta->addProperty($prop->name->toString(), $propType);
                         }

--- a/app/PicoHP/PicoType.php
+++ b/app/PicoHP/PicoType.php
@@ -21,7 +21,7 @@ enum BaseType: string
             BaseType::FLOAT => 'double',
             BaseType::BOOL => 'i1',
             BaseType::VOID => 'void',
-            BaseType::STRING => "ptr",
+            BaseType::STRING, BaseType::PTR => 'ptr',
             default => 'i8*',
         };
     }
@@ -82,6 +82,10 @@ class PicoType
         }
         if (preg_match('/^array<[^,]+,\s*(\w+)>$/', $type, $m) === 1) {
             return self::array(self::fromString($m[1]));
+        }
+        if ($type === 'array') {
+            // Bare array type without generics — untyped, element type unknown
+            return self::array(new PicoType(BaseType::PTR));
         }
         $baseType = BaseType::tryFrom($type);
         if ($baseType !== null) {

--- a/tests/Feature/ArrayPropertyTest.php
+++ b/tests/Feature/ArrayPropertyTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles array-typed class properties', function () {
+    $file = 'tests/programs/classes/array_property.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/classes/array_property.php
+++ b/tests/programs/classes/array_property.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+class Bag
+{
+    /** @var array<int, string> */
+    public array $items;
+
+    public function __construct()
+    {
+        $this->items = [];
+    }
+
+    public function add(string $item): void
+    {
+        $this->items[] = $item;
+    }
+
+    public function count(): int
+    {
+        return count($this->items);
+    }
+}
+
+$bag = new Bag();
+$bag->add('apple');
+$bag->add('banana');
+$bag->add('cherry');
+
+echo $bag->count();
+echo "\n";
+
+foreach ($bag->items as $item) {
+    echo $item;
+    echo "\n";
+}


### PR DESCRIPTION
## Summary
- Handle `array` type hint in `PicoType::fromString()` 
- Use PHPDoc `@var` annotations on class properties for generic element type info
- Fix `BaseType::PTR` toLLVM to return `ptr` instead of `i8*` (opaque pointer fix)
- Generalize array push/set/foreach to work with `PropertyFetch` expressions, not just variables
- Fix lVal loading for array operations through object properties

## What works
```php
class Bag {
    /** @var array<int, string> */
    public array $items;
    public function __construct() { $this->items = []; }
    public function add(string $item): void { $this->items[] = $item; }
    public function count(): int { return count($this->items); }
}
$bag = new Bag();
$bag->add('apple');
echo $bag->count();           // 3
foreach ($bag->items as $item) { echo $item; }
```

Closes #73

## Test plan
- [x] `array_property.php` — class with array property, push, count, foreach
- [x] All 64 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)