### PR TITLE
feat: add str_starts_with, str_contains, substr, trim built-ins

### DIFF
--- a/app/PicoHP/LLVM/Builder.php
+++ b/app/PicoHP/LLVM/Builder.php
@@ -32,6 +32,10 @@ class Builder
         $this->addLine('declare ptr @pico_string_concat(ptr, ptr)');
         $this->addLine('declare i32 @pico_rt_version()');
         $this->addLine('declare i32 @pico_string_len(ptr)');
+        $this->addLine('declare i32 @pico_string_starts_with(ptr, ptr)');
+        $this->addLine('declare i32 @pico_string_contains(ptr, ptr)');
+        $this->addLine('declare ptr @pico_string_substr(ptr, i32, i32)');
+        $this->addLine('declare ptr @pico_string_trim(ptr)');
         $this->addLine('declare ptr @picohp_object_alloc(i64, i32)');
         $this->addLine();
         $this->addLine('; array runtime');

--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -511,6 +511,41 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                 $strVal = $this->buildExpr($expr->args[0]->value);
                 return $this->builder->createStringLen($strVal);
             }
+            if ($funcName === 'str_starts_with') {
+                assert(count($expr->args) === 2);
+                assert($expr->args[0] instanceof \PhpParser\Node\Arg);
+                assert($expr->args[1] instanceof \PhpParser\Node\Arg);
+                $haystack = $this->buildExpr($expr->args[0]->value);
+                $prefix = $this->buildExpr($expr->args[1]->value);
+                $result = $this->builder->createCall('pico_string_starts_with', [$haystack, $prefix], BaseType::INT);
+                return $this->builder->createInstruction('icmp ne', [$result, new Constant(0, BaseType::INT)], resultType: BaseType::BOOL);
+            }
+            if ($funcName === 'str_contains') {
+                assert(count($expr->args) === 2);
+                assert($expr->args[0] instanceof \PhpParser\Node\Arg);
+                assert($expr->args[1] instanceof \PhpParser\Node\Arg);
+                $haystack = $this->buildExpr($expr->args[0]->value);
+                $needle = $this->buildExpr($expr->args[1]->value);
+                $result = $this->builder->createCall('pico_string_contains', [$haystack, $needle], BaseType::INT);
+                return $this->builder->createInstruction('icmp ne', [$result, new Constant(0, BaseType::INT)], resultType: BaseType::BOOL);
+            }
+            if ($funcName === 'substr') {
+                assert(count($expr->args) >= 2 && count($expr->args) <= 3);
+                assert($expr->args[0] instanceof \PhpParser\Node\Arg);
+                assert($expr->args[1] instanceof \PhpParser\Node\Arg);
+                $strVal = $this->buildExpr($expr->args[0]->value);
+                $start = $this->buildExpr($expr->args[1]->value);
+                $len = count($expr->args) === 3 && $expr->args[2] instanceof \PhpParser\Node\Arg
+                    ? $this->buildExpr($expr->args[2]->value)
+                    : new Constant(2147483647, BaseType::INT);
+                return $this->builder->createCall('pico_string_substr', [$strVal, $start, $len], BaseType::STRING);
+            }
+            if ($funcName === 'trim') {
+                assert(count($expr->args) === 1);
+                assert($expr->args[0] instanceof \PhpParser\Node\Arg);
+                $strVal = $this->buildExpr($expr->args[0]->value);
+                return $this->builder->createCall('pico_string_trim', [$strVal], BaseType::STRING);
+            }
             $args = (new Collection($expr->args))
                 ->map(function ($arg): ValueAbstract {
                     assert($arg instanceof \PhpParser\Node\Arg);

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -398,6 +398,12 @@ class SemanticAnalysisPass implements PassInterface
             if ($funcName === 'count' || $funcName === 'strlen') {
                 return PicoType::fromString('int');
             }
+            if ($funcName === 'str_starts_with' || $funcName === 'str_contains') {
+                return PicoType::fromString('bool');
+            }
+            if ($funcName === 'substr' || $funcName === 'trim') {
+                return PicoType::fromString('string');
+            }
             $s = $this->symbolTable->lookup($expr->name->name);
             $line = $this->getLine($expr);
             assert($s !== null, "line {$line}, function {$expr->name->name} not found");

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -33,6 +33,67 @@ pub extern "C" fn pico_string_len(s: *const c_char) -> i32 {
     s.to_bytes().len() as i32
 }
 
+#[no_mangle]
+pub extern "C" fn pico_string_starts_with(haystack: *const c_char, prefix: *const c_char) -> i32 {
+    let h = unsafe { CStr::from_ptr(haystack) }.to_bytes();
+    let p = unsafe { CStr::from_ptr(prefix) }.to_bytes();
+    h.starts_with(p) as i32
+}
+
+#[no_mangle]
+pub extern "C" fn pico_string_contains(haystack: *const c_char, needle: *const c_char) -> i32 {
+    let h = unsafe { CStr::from_ptr(haystack) }.to_bytes();
+    let n = unsafe { CStr::from_ptr(needle) }.to_bytes();
+    // windows() doesn't work for empty needle; match PHP behavior (always true)
+    if n.is_empty() {
+        return 1;
+    }
+    h.windows(n.len()).any(|w| w == n) as i32
+}
+
+/// Returns a heap-allocated substring. Negative $start counts from end.
+/// If $length is negative, it's treated as 0 (returns empty string).
+#[no_mangle]
+pub extern "C" fn pico_string_substr(s: *const c_char, start: i32, length: i32) -> *mut c_char {
+    let bytes = unsafe { CStr::from_ptr(s) }.to_bytes();
+    let len = bytes.len() as i32;
+
+    let actual_start = if start < 0 {
+        (len + start).max(0) as usize
+    } else {
+        start.min(len) as usize
+    };
+
+    let actual_len = if length < 0 {
+        0
+    } else {
+        length.min(len - actual_start as i32).max(0) as usize
+    };
+
+    let slice = &bytes[actual_start..actual_start + actual_len];
+    let mut result = Vec::with_capacity(slice.len() + 1);
+    result.extend_from_slice(slice);
+    result.push(0);
+    let ptr = result.as_mut_ptr() as *mut c_char;
+    std::mem::forget(result);
+    ptr
+}
+
+#[no_mangle]
+pub extern "C" fn pico_string_trim(s: *const c_char) -> *mut c_char {
+    let bytes = unsafe { CStr::from_ptr(s) }.to_bytes();
+    let trimmed = match std::str::from_utf8(bytes) {
+        Ok(s) => s.trim().as_bytes(),
+        Err(_) => bytes, // non-UTF8: return as-is
+    };
+    let mut result = Vec::with_capacity(trimmed.len() + 1);
+    result.extend_from_slice(trimmed);
+    result.push(0);
+    let ptr = result.as_mut_ptr() as *mut c_char;
+    std::mem::forget(result);
+    ptr
+}
+
 // ---------------------------------------------------------------------------
 // Object allocation
 // ---------------------------------------------------------------------------
@@ -197,6 +258,49 @@ mod tests {
         assert_eq!(pico_string_len(s.as_ptr()), 5);
         let empty = CString::new("").unwrap();
         assert_eq!(pico_string_len(empty.as_ptr()), 0);
+    }
+
+    #[test]
+    fn test_string_starts_with() {
+        let h = CString::new("hello world").unwrap();
+        let p1 = CString::new("hello").unwrap();
+        let p2 = CString::new("world").unwrap();
+        let p3 = CString::new("").unwrap();
+        assert_eq!(pico_string_starts_with(h.as_ptr(), p1.as_ptr()), 1);
+        assert_eq!(pico_string_starts_with(h.as_ptr(), p2.as_ptr()), 0);
+        assert_eq!(pico_string_starts_with(h.as_ptr(), p3.as_ptr()), 1);
+    }
+
+    #[test]
+    fn test_string_contains() {
+        let h = CString::new("hello world").unwrap();
+        let n1 = CString::new("world").unwrap();
+        let n2 = CString::new("xyz").unwrap();
+        let n3 = CString::new("").unwrap();
+        assert_eq!(pico_string_contains(h.as_ptr(), n1.as_ptr()), 1);
+        assert_eq!(pico_string_contains(h.as_ptr(), n2.as_ptr()), 0);
+        assert_eq!(pico_string_contains(h.as_ptr(), n3.as_ptr()), 1);
+    }
+
+    #[test]
+    fn test_string_substr() {
+        let s = CString::new("hello world").unwrap();
+        let r1 = pico_string_substr(s.as_ptr(), 0, 5);
+        assert_eq!(unsafe { CStr::from_ptr(r1) }.to_str().unwrap(), "hello");
+        let r2 = pico_string_substr(s.as_ptr(), 6, 5);
+        assert_eq!(unsafe { CStr::from_ptr(r2) }.to_str().unwrap(), "world");
+        let r3 = pico_string_substr(s.as_ptr(), -5, 5);
+        assert_eq!(unsafe { CStr::from_ptr(r3) }.to_str().unwrap(), "world");
+    }
+
+    #[test]
+    fn test_string_trim() {
+        let s = CString::new("  hello  ").unwrap();
+        let r = pico_string_trim(s.as_ptr());
+        assert_eq!(unsafe { CStr::from_ptr(r) }.to_str().unwrap(), "hello");
+        let s2 = CString::new("nospace").unwrap();
+        let r2 = pico_string_trim(s2.as_ptr());
+        assert_eq!(unsafe { CStr::from_ptr(r2) }.to_str().unwrap(), "nospace");
     }
 
     #[test]

--- a/tests/Feature/BuiltinFunctionTest.php
+++ b/tests/Feature/BuiltinFunctionTest.php
@@ -16,6 +16,20 @@ it('handles count() on arrays', function () {
     expect($compiled_output)->toBe($php_output);
 });
 
+it('handles string built-in functions', function () {
+    $file = 'tests/programs/functions/builtin_strings.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
 it('handles strlen() on strings', function () {
     $file = 'tests/programs/functions/builtin_strlen.php';
 

--- a/tests/programs/functions/builtin_strings.php
+++ b/tests/programs/functions/builtin_strings.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+echo str_starts_with('hello world', 'hello');
+echo "\n";
+echo str_starts_with('hello world', 'world');
+echo "\n";
+echo str_contains('hello world', 'lo wo');
+echo "\n";
+echo str_contains('hello world', 'xyz');
+echo "\n";
+echo substr('hello world', 6, 5);
+echo "\n";
+echo substr('hello world', 0, 5);
+echo "\n";
+echo trim('  hello  ');
+echo "\n";


### PR DESCRIPTION
## Summary
- Add 4 string functions to Rust runtime: `pico_string_starts_with`, `pico_string_contains`, `pico_string_substr`, `pico_string_trim`
- Wire up `str_starts_with()`, `str_contains()`, `substr()`, `trim()` as compiler built-ins
- `str_starts_with`/`str_contains` return `bool` (i32 from runtime, converted to i1)
- `substr` supports negative start index and optional length parameter
- 18 Rust unit tests, 1 new integration test

Partial #69

## Test plan
- [x] `builtin_strings.php` — all 4 functions with various inputs
- [x] All 65 tests pass, no regressions
- [x] 18 Rust runtime tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)