### PR TITLE
feat: add class inheritance support

### DIFF
--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -628,7 +628,8 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                     ->toArray();
                 /** @var array<ValueAbstract> $allArgs */
                 $allArgs = array_merge([$objPtr], $args);
-                $qualifiedName = "{$className}___construct";
+                $ctorOwner = $classMeta->methodOwner['__construct'] ?? $className;
+                $qualifiedName = "{$ctorOwner}___construct";
                 $this->builder->createCall($qualifiedName, $allArgs, BaseType::VOID);
             }
             return $objPtr;
@@ -664,7 +665,8 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                 ->toArray();
             /** @var array<ValueAbstract> $allArgs */
             $allArgs = array_merge([$objVal], $args);
-            $qualifiedName = "{$className}_{$methodName}";
+            $ownerClass = $classMeta->methodOwner[$methodName] ?? $className;
+            $qualifiedName = "{$ownerClass}_{$methodName}";
             return $this->builder->createCall($qualifiedName, $allArgs, $methodSymbol->type->toBase());
         } else {
             throw new \Exception("unknown node type in expr: " . get_class($expr));

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -69,6 +69,12 @@ class SemanticAnalysisPass implements PassInterface
                 $className = $stmt->name->toString();
                 $classMeta = new ClassMetadata($className);
                 $this->classRegistry[$className] = $classMeta;
+                // Inherit from parent class
+                if ($stmt->extends !== null) {
+                    $parentName = $stmt->extends->toString();
+                    assert(isset($this->classRegistry[$parentName]), "parent class {$parentName} not found");
+                    $classMeta->inheritFrom($this->classRegistry[$parentName]);
+                }
                 foreach ($stmt->stmts as $classStmt) {
                     if ($classStmt instanceof \PhpParser\Node\Stmt\Property) {
                         assert($classStmt->type instanceof \PhpParser\Node\Identifier || $classStmt->type instanceof \PhpParser\Node\NullableType);
@@ -90,6 +96,7 @@ class SemanticAnalysisPass implements PassInterface
                             : PicoType::fromString('void');
                         $methodSymbol = new \App\PicoHP\SymbolTable\Symbol($methodName, $returnType, func: true);
                         $classMeta->methods[$methodName] = $methodSymbol;
+                        $classMeta->methodOwner[$methodName] = $className;
                     }
                 }
             }

--- a/app/PicoHP/SymbolTable/ClassMetadata.php
+++ b/app/PicoHP/SymbolTable/ClassMetadata.php
@@ -9,6 +9,7 @@ use App\PicoHP\PicoType;
 class ClassMetadata
 {
     public string $name;
+    public ?string $parentName = null;
 
     /** @var array<string, PicoType> property name => type */
     public array $properties = [];
@@ -19,9 +20,27 @@ class ClassMetadata
     /** @var array<string, Symbol> method name => symbol (with params/return type) */
     public array $methods = [];
 
+    /** @var array<string, string> method name => defining class name (for qualified call) */
+    public array $methodOwner = [];
+
     public function __construct(string $name)
     {
         $this->name = $name;
+    }
+
+    public function inheritFrom(ClassMetadata $parent): void
+    {
+        $this->parentName = $parent->name;
+        // Copy parent properties first (preserving offsets)
+        foreach ($parent->properties as $propName => $propType) {
+            $this->properties[$propName] = $propType;
+            $this->propertyOffsets[$propName] = $parent->propertyOffsets[$propName];
+        }
+        // Copy parent methods (child can override later)
+        foreach ($parent->methods as $methodName => $methodSymbol) {
+            $this->methods[$methodName] = $methodSymbol;
+            $this->methodOwner[$methodName] = $parent->methodOwner[$methodName] ?? $parent->name;
+        }
     }
 
     public function addProperty(string $name, PicoType $type): int

--- a/tests/Feature/InheritanceTest.php
+++ b/tests/Feature/InheritanceTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles class inheritance', function () {
+    $file = 'tests/programs/classes/inheritance.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/classes/inheritance.php
+++ b/tests/programs/classes/inheritance.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+class Shape
+{
+    public string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function describe(): string
+    {
+        return $this->name;
+    }
+}
+
+class Circle extends Shape
+{
+    public int $radius;
+
+    public function __construct(int $radius)
+    {
+        $this->name = 'circle';
+        $this->radius = $radius;
+    }
+
+    public function area(): int
+    {
+        return 3 * $this->radius * $this->radius;
+    }
+}
+
+$s = new Shape('square');
+echo $s->describe();
+echo "\n";
+
+$c = new Circle(5);
+echo $c->describe();
+echo "\n";
+echo $c->area();
+echo "\n";
+echo $c->name;
+echo "\n";


### PR DESCRIPTION
## Summary
- Child class struct layout embeds parent fields at the same offsets (layout-compatible upcasting)
- `ClassMetadata::inheritFrom()` copies parent properties, methods, and tracks method ownership
- Inherited method calls dispatch to the defining class's function (`Shape_describe` not `Circle_describe`)
- Property access on inherited fields works via GEP at parent offsets

## What works
```php
class Shape {
    public string $name;
    public function describe(): string { return $this->name; }
}
class Circle extends Shape {
    public int $radius;
    public function area(): int { return 3 * $this->radius * $this->radius; }
}
$c = new Circle(5);
echo $c->describe(); // "circle" — inherited method
echo $c->name;       // "circle" — inherited property
echo $c->area();     // 75 — own method
```

Partial #65

## Test plan
- [x] `inheritance.php` — parent/child properties, inherited methods, own methods
- [x] All 66 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)