### PR TITLE
feat: support abstract classes and abstract methods

### DIFF
--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -207,6 +207,10 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Property) {
             // Handled by struct type definition
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\ClassMethod) {
+            // Abstract methods have no body — skip IR generation
+            if ($stmt->stmts === null) {
+                return;
+            }
             assert($this->currentClassName !== null);
             $methodName = $stmt->name->toString();
             $funcSymbol = $pData->getSymbol();
@@ -237,7 +241,6 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                 $type = $paramPData->getSymbol()->type;
                 $this->builder->createStore(new Param($paramIndex++, $type->toBase()), $paramPData->getValue());
             }
-            assert($stmt->stmts !== null);
             $this->buildStmts($stmt->stmts);
             if ($funcSymbol->type->toBase() === \App\PicoHP\BaseType::VOID) {
                 $this->builder->createRetVoid();

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -277,11 +277,16 @@ class SemanticAnalysisPass implements PassInterface
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\ClassMethod) {
             assert($this->currentClass !== null);
             $methodName = $stmt->name->toString();
+            // Abstract methods have no body — already registered in registerClasses
+            if ($stmt->stmts === null) {
+                return;
+            }
             assert($stmt->returnType instanceof \PhpParser\Node\Identifier || $stmt->returnType instanceof \PhpParser\Node\NullableType || $stmt->returnType instanceof \PhpParser\Node\Name || $stmt->returnType === null);
             $returnType = $stmt->returnType !== null ? $this->typeFromNode($stmt->returnType) : PicoType::fromString('void');
             $methodSymbol = $this->symbolTable->addSymbol($methodName, $returnType, func: true);
             $pData->symbol = $methodSymbol;
             $this->currentClass->methods[$methodName] = $methodSymbol;
+            $this->currentClass->methodOwner[$methodName] = $this->currentClass->name;
             $pData->setScope($this->symbolTable->enterScope());
             // Add $this to method scope
             $this->symbolTable->addSymbol('this', PicoType::object($this->currentClass->name));
@@ -291,7 +296,6 @@ class SemanticAnalysisPass implements PassInterface
             $methodSymbol->paramNames = $paramNames;
             $previousReturnType = $this->currentFunctionReturnType;
             $this->currentFunctionReturnType = $returnType;
-            assert($stmt->stmts !== null);
             $this->resolveStmts($stmt->stmts);
             $this->currentFunctionReturnType = $previousReturnType;
             $this->symbolTable->exitScope();

--- a/tests/Feature/AbstractClassTest.php
+++ b/tests/Feature/AbstractClassTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles abstract classes with concrete subclasses', function () {
+    $file = 'tests/programs/classes/abstract_class.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/classes/abstract_class.php
+++ b/tests/programs/classes/abstract_class.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+abstract class Vehicle
+{
+    public string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    abstract public function wheels(): int;
+
+    public function describe(): string
+    {
+        return $this->name;
+    }
+}
+
+class Car extends Vehicle
+{
+    public function __construct()
+    {
+        parent::__construct('car');
+    }
+
+    public function wheels(): int
+    {
+        return 4;
+    }
+}
+
+class Bike extends Vehicle
+{
+    public function __construct()
+    {
+        parent::__construct('bike');
+    }
+
+    public function wheels(): int
+    {
+        return 2;
+    }
+}
+
+$c = new Car();
+echo $c->describe();
+echo "\n";
+echo $c->wheels();
+echo "\n";
+
+$b = new Bike();
+echo $b->describe();
+echo "\n";


### PR DESCRIPTION
## Summary
- Abstract methods (null stmts) are skipped in both semantic and IR passes
- Abstract classes work as base classes with full inheritance
- Concrete subclasses override abstract methods with direct dispatch

## Self-compilation impact
- `ValueAbstract.php` now compiles — unlocks the entire LLVM Value class hierarchy
- Self-host score: 22 → 24 files (7.4% → 8.1%)

Partial #65

## Test plan
- [x] `abstract_class.php` — abstract Vehicle with Car/Bike subclasses
- [x] All 74 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)