### PR TITLE
feat: support static class properties

### DIFF
--- a/app/PicoHP/ClassToFunctionVisitor.php
+++ b/app/PicoHP/ClassToFunctionVisitor.php
@@ -58,6 +58,15 @@ class ClassToFunctionVisitor extends NodeVisitorAbstract
             return NodeTraverser::REMOVE_NODE;
         }
 
+        // Resolve self:: in static property access to the actual class name
+        if ($node instanceof Node\Expr\StaticPropertyFetch) {
+            if ($node->class instanceof Node\Name && $node->class->toString() === 'self') {
+                assert($this->className !== null);
+                $node->class = new Node\Name($this->className);
+            }
+            return $node;
+        }
+
         // Convert static method calls (e.g., MyClass::methodName())
         // Skip parent:: and self:: — handled by semantic/IR passes
         if ($node instanceof Node\Expr\StaticCall) {

--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -200,7 +200,30 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             assert(isset($this->classRegistry[$className]));
             $classMeta = $this->classRegistry[$className];
             $fields = $classMeta->toLLVMStructFields();
-            $this->module->addLine(new IRLine("%struct.{$className} = type { {$fields} }"));
+            if ($fields !== '') {
+                $this->module->addLine(new IRLine("%struct.{$className} = type { {$fields} }"));
+            }
+            // Emit static properties as globals
+            foreach ($classMeta->staticProperties as $propName => $propType) {
+                $llvmType = $propType->toBase()->toLLVM();
+                $default = $classMeta->staticDefaults[$propName] ?? null;
+                $initVal = '0';
+                if ($default instanceof \PhpParser\Node\Scalar\Int_) {
+                    $initVal = (string) $default->value;
+                } elseif ($default instanceof \PhpParser\Node\Scalar\Float_) {
+                    $initVal = sprintf('%e', $default->value);
+                } elseif ($default instanceof \PhpParser\Node\Scalar\String_) {
+                    $initVal = 'null'; // string pointers default to null
+                } elseif ($default instanceof \PhpParser\Node\Expr\ConstFetch) {
+                    $name = $default->name->toLowerString();
+                    if ($name === 'true') {
+                        $initVal = '1';
+                    } elseif ($name === 'false' || $name === 'null') {
+                        $initVal = '0';
+                    }
+                }
+                $this->module->addLine(new IRLine("@{$className}_{$propName} = global {$llvmType} {$initVal}"));
+            }
             $this->currentClassName = $className;
             $this->buildStmts($stmt->stmts);
             $this->currentClassName = null;
@@ -701,6 +724,23 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             }
             $qualifiedName = "{$targetClass}_{$methodName}";
             return $this->builder->createCall($qualifiedName, $allArgs, $methodSymbol->type->toBase());
+        } elseif ($expr instanceof \PhpParser\Node\Expr\StaticPropertyFetch) {
+            assert($expr->class instanceof \PhpParser\Node\Name);
+            assert($expr->name instanceof \PhpParser\Node\VarLikeIdentifier);
+            $className = $expr->class->toString();
+            if ($className === 'self') {
+                assert($this->currentClassName !== null);
+                $className = $this->currentClassName;
+            }
+            $propName = $expr->name->toString();
+            $classMeta = $this->classRegistry[$className];
+            $propType = $classMeta->staticProperties[$propName];
+            $globalName = "{$className}_{$propName}";
+            $globalPtr = new \App\PicoHP\LLVM\Value\Global_($globalName, $propType->toBase());
+            if ($pData->lVal) {
+                return $globalPtr;
+            }
+            return $this->builder->createLoad($globalPtr);
         } else {
             throw new \Exception("unknown node type in expr: " . get_class($expr));
         }

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -82,15 +82,21 @@ class SemanticAnalysisPass implements PassInterface
                 foreach ($stmt->stmts as $classStmt) {
                     if ($classStmt instanceof \PhpParser\Node\Stmt\Property) {
                         assert($classStmt->type instanceof \PhpParser\Node\Identifier || $classStmt->type instanceof \PhpParser\Node\NullableType || $classStmt->type instanceof \PhpParser\Node\Name);
-                        // Use PHPDoc annotation if available (for generic types like array<int, string>)
                         $doc = $classStmt->getDocComment();
                         if ($doc !== null) {
                             $propType = $this->docTypeParser->parseType($doc->getText());
                         } else {
                             $propType = $this->typeFromNode($classStmt->type);
                         }
-                        foreach ($classStmt->props as $prop) {
-                            $classMeta->addProperty($prop->name->toString(), $propType);
+                        if ($classStmt->isStatic()) {
+                            foreach ($classStmt->props as $prop) {
+                                $classMeta->staticProperties[$prop->name->toString()] = $propType;
+                                $classMeta->staticDefaults[$prop->name->toString()] = $prop->default;
+                            }
+                        } else {
+                            foreach ($classStmt->props as $prop) {
+                                $classMeta->addProperty($prop->name->toString(), $propType);
+                            }
                         }
                     } elseif ($classStmt instanceof \PhpParser\Node\Stmt\ClassMethod) {
                         $methodName = $classStmt->name->toString();
@@ -496,6 +502,19 @@ class SemanticAnalysisPass implements PassInterface
             assert(isset($classMeta->methods[$methodName]), "method {$methodName} not found on class {$className}");
             $this->resolveArgs($expr->args);
             return $classMeta->methods[$methodName]->type;
+        } elseif ($expr instanceof \PhpParser\Node\Expr\StaticPropertyFetch) {
+            $pData->lVal = $lVal;
+            assert($expr->class instanceof \PhpParser\Node\Name);
+            assert($expr->name instanceof \PhpParser\Node\VarLikeIdentifier);
+            $className = $expr->class->toString();
+            if ($className === 'self') {
+                assert($this->currentClass !== null);
+                $className = $this->currentClass->name;
+            }
+            $classMeta = $this->classRegistry[$className];
+            $propName = $expr->name->toString();
+            assert(isset($classMeta->staticProperties[$propName]), "static property {$propName} not found on {$className}");
+            return $classMeta->staticProperties[$propName];
         } elseif ($expr instanceof \PhpParser\Node\Expr\StaticCall) {
             assert($expr->class instanceof \PhpParser\Node\Name);
             assert($expr->name instanceof \PhpParser\Node\Identifier);

--- a/app/PicoHP/SymbolTable/ClassMetadata.php
+++ b/app/PicoHP/SymbolTable/ClassMetadata.php
@@ -23,6 +23,12 @@ class ClassMetadata
     /** @var array<string, string> method name => defining class name (for qualified call) */
     public array $methodOwner = [];
 
+    /** @var array<string, PicoType> static property name => type */
+    public array $staticProperties = [];
+
+    /** @var array<string, \PhpParser\Node\Expr|null> static property name => default value expression */
+    public array $staticDefaults = [];
+
     public function __construct(string $name)
     {
         $this->name = $name;

--- a/tests/Feature/StaticPropertyTest.php
+++ b/tests/Feature/StaticPropertyTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles static class properties', function () {
+    $file = 'tests/programs/classes/static_property.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/classes/static_property.php
+++ b/tests/programs/classes/static_property.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+class Counter
+{
+    public static int $count = 0;
+
+    public static function next(): int
+    {
+        $val = self::$count;
+        self::$count = self::$count + 1;
+        return $val;
+    }
+}
+
+echo Counter::next();
+echo "\n";
+echo Counter::next();
+echo "\n";
+echo Counter::next();
+echo "\n";
+echo Counter::$count;
+echo "\n";


### PR DESCRIPTION
## Summary
- Static properties emitted as LLVM global variables (`@Counter_count = global i32 0`)
- `self::$prop` and `ClassName::$prop` resolve to load/store on globals
- `ClassToFunctionVisitor` resolves `self::` to the actual class name for properties
- `ClassMetadata` tracks static properties separately from instance struct fields

## What works
```php
class Counter {
    public static int $count = 0;
    public static function next(): int {
        $val = self::$count;
        self::$count = self::$count + 1;
        return $val;
    }
}
echo Counter::next();  // 0
echo Counter::next();  // 1
echo Counter::$count;  // 2
```

Closes #89

## Test plan
- [x] `static_property.php` — static counter with read, write, increment
- [x] All 75 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)