### PR TITLE
feat: add multi-file compilation testing to self-host checker

### DIFF
--- a/self-host-check.php
+++ b/self-host-check.php
@@ -6,104 +6,218 @@
  *
  * Attempts to compile each PHP source file in the compiler codebase
  * and nikic/php-parser, reporting which files succeed and which fail.
+ * Also tests multi-file compilation of related file groups.
  *
- * Usage: php self-host-check.php [--verbose]
+ * Usage: php self-host-check.php [--verbose] [--multi]
  */
 
 $verbose = in_array('--verbose', $argv, true);
+$multiOnly = in_array('--multi', $argv, true);
 $picoHP = __DIR__ . '/picoHP';
 $buildPath = __DIR__ . '/build';
+$tmpDir = sys_get_temp_dir() . '/picohp-multi-test';
 
-$dirs = [
-    'picoHP compiler' => __DIR__ . '/app/PicoHP',
-    'nikic/php-parser' => __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser',
-];
+if (!$multiOnly) {
+    singleFileCheck($picoHP, $verbose);
+}
 
-$pass = 0;
-$fail = 0;
-$total = 0;
-$errors = [];
+multiFileCheck($picoHP, $tmpDir, $verbose);
 
-foreach ($dirs as $label => $dir) {
-    if (!is_dir($dir)) {
-        echo "⚠ Skipping {$label}: directory not found\n";
-        continue;
-    }
+function singleFileCheck(string $picoHP, bool $verbose): void
+{
+    $dirs = [
+        'picoHP compiler' => __DIR__ . '/app/PicoHP',
+        'nikic/php-parser' => __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser',
+    ];
 
-    echo "\n━━━ {$label} ━━━\n";
+    $pass = 0;
+    $fail = 0;
+    $total = 0;
+    $errors = [];
 
-    $files = new RecursiveIteratorIterator(
-        new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS)
-    );
-
-    $results = [];
-
-    foreach ($files as $file) {
-        if ($file->getExtension() !== 'php') {
+    foreach ($dirs as $label => $dir) {
+        if (!is_dir($dir)) {
+            echo "⚠ Skipping {$label}: directory not found\n";
             continue;
         }
 
-        $path = $file->getPathname();
-        $relative = str_replace(__DIR__ . '/', '', $path);
-        $total++;
+        echo "\n━━━ {$label} (single-file) ━━━\n";
 
-        // Try to compile (capture stderr)
-        $output = [];
-        $exitCode = 0;
-        exec("{$picoHP} build {$path} 2>&1", $output, $exitCode);
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS)
+        );
 
-        if ($exitCode === 0) {
-            $pass++;
-            $results[] = ['status' => 'pass', 'file' => $relative, 'error' => ''];
-        } else {
-            $fail++;
-            // Extract first meaningful error line
-            $errorMsg = '';
-            foreach ($output as $line) {
-                $line = trim($line);
-                if ($line !== '' && !str_starts_with($line, '#') && !str_starts_with($line, 'at ')) {
-                    $errorMsg = $line;
-                    break;
+        $results = [];
+
+        foreach ($files as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $path = $file->getPathname();
+            $relative = str_replace(__DIR__ . '/', '', $path);
+            $total++;
+
+            $output = [];
+            $exitCode = 0;
+            exec("{$picoHP} build {$path} 2>&1", $output, $exitCode);
+
+            if ($exitCode === 0) {
+                $pass++;
+                $results[] = ['status' => 'pass', 'file' => $relative, 'error' => ''];
+            } else {
+                $fail++;
+                $errorMsg = extractError($output);
+                $results[] = ['status' => 'fail', 'file' => $relative, 'error' => $errorMsg];
+                $errors[$errorMsg] = ($errors[$errorMsg] ?? 0) + 1;
+            }
+        }
+
+        usort($results, fn ($a, $b) => $a['status'] <=> $b['status']);
+
+        foreach ($results as $r) {
+            if ($r['status'] === 'pass') {
+                echo "  ✅ {$r['file']}\n";
+            } else {
+                if ($verbose) {
+                    echo "  ❌ {$r['file']}\n     {$r['error']}\n";
+                } else {
+                    echo "  ❌ {$r['file']}\n";
                 }
             }
-            // Shorten common error patterns
-            if (preg_match('/unknown node type.*: (.+)/', $errorMsg, $m)) {
-                $errorMsg = 'unsupported: ' . basename($m[1]);
-            } elseif (preg_match('/function (.+) not found/', $errorMsg, $m)) {
-                $errorMsg = 'missing function: ' . $m[1];
-            } elseif (preg_match('/assert\((.+)\)/', $errorMsg, $m)) {
-                $errorMsg = 'assert: ' . substr($m[1], 0, 60);
-            }
-            $results[] = ['status' => 'fail', 'file' => $relative, 'error' => $errorMsg];
-            $errors[$errorMsg] = ($errors[$errorMsg] ?? 0) + 1;
         }
     }
 
-    // Sort: passes first, then fails
-    usort($results, fn ($a, $b) => $a['status'] <=> $b['status']);
+    echo "\n━━━ Single-file summary ━━━\n";
+    echo "  Total: {$total}  Pass: {$pass}  Fail: {$fail}\n";
+    $pct = $total > 0 ? round($pass / $total * 100, 1) : 0;
+    echo "  Success rate: {$pct}%\n";
 
-    foreach ($results as $r) {
-        if ($r['status'] === 'pass') {
-            echo "  ✅ {$r['file']}\n";
-        } else {
-            if ($verbose) {
-                echo "  ❌ {$r['file']}\n     {$r['error']}\n";
-            } else {
-                echo "  ❌ {$r['file']}\n";
-            }
+    if ($verbose && count($errors) > 0) {
+        echo "\n━━━ Error frequency ━━━\n";
+        arsort($errors);
+        foreach (array_slice($errors, 0, 15) as $msg => $count) {
+            echo "  {$count}x  {$msg}\n";
         }
     }
 }
 
-echo "\n━━━ Summary ━━━\n";
-echo "  Total: {$total}  Pass: {$pass}  Fail: {$fail}\n";
-$pct = $total > 0 ? round($pass / $total * 100, 1) : 0;
-echo "  Success rate: {$pct}%\n";
+function multiFileCheck(string $picoHP, string $tmpDir, bool $verbose): void
+{
+    echo "\n━━━ Multi-file groups ━━━\n";
 
-if ($verbose && count($errors) > 0) {
-    echo "\n━━━ Error frequency ━━━\n";
-    arsort($errors);
-    foreach (array_slice($errors, 0, 15) as $msg => $count) {
-        echo "  {$count}x  {$msg}\n";
+    @mkdir($tmpDir, 0755, true);
+
+    $groups = [
+        'LLVM Value hierarchy' => [
+            __DIR__ . '/app/PicoHP/LLVM/ValueAbstract.php',
+            __DIR__ . '/app/PicoHP/LLVM/Value/Void_.php',
+            __DIR__ . '/app/PicoHP/LLVM/Value/NullConstant.php',
+            __DIR__ . '/app/PicoHP/LLVM/Value/Param.php',
+            __DIR__ . '/app/PicoHP/LLVM/Value/Global_.php',
+            __DIR__ . '/app/PicoHP/LLVM/Value/Instruction.php',
+            __DIR__ . '/app/PicoHP/LLVM/Value/AllocaInst.php',
+            __DIR__ . '/app/PicoHP/LLVM/Value/Label.php',
+            __DIR__ . '/app/PicoHP/LLVM/Value/Constant.php',
+        ],
+        'LLVM IR infrastructure' => [
+            __DIR__ . '/app/PicoHP/LLVM/IRLine.php',
+            __DIR__ . '/app/PicoHP/LLVM/BasicBlock.php',
+        ],
+        'Symbol table' => [
+            __DIR__ . '/app/PicoHP/SymbolTable/Symbol.php',
+            __DIR__ . '/app/PicoHP/SymbolTable/Scope.php',
+            __DIR__ . '/app/PicoHP/SymbolTable.php',
+        ],
+        'php-parser Node base' => [
+            __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/NodeAbstract.php',
+            __DIR__ . '/vendor/nikic/php-parser/lib/PhpParser/Comment.php',
+        ],
+        'picoHP ClassMetadata + Symbol' => [
+            __DIR__ . '/app/PicoHP/SymbolTable/Symbol.php',
+            __DIR__ . '/app/PicoHP/SymbolTable/ClassMetadata.php',
+        ],
+        'picoHP PassInterface + IRLine' => [
+            __DIR__ . '/app/PicoHP/PassInterface.php',
+            __DIR__ . '/app/PicoHP/LLVM/IRLine.php',
+        ],
+    ];
+
+    $groupPass = 0;
+    $groupFail = 0;
+
+    foreach ($groups as $name => $files) {
+        // Verify all files exist
+        $missing = array_filter($files, fn ($f) => !file_exists($f));
+        if (count($missing) > 0) {
+            echo "  ⚠ {$name}: missing files\n";
+            continue;
+        }
+
+        // Concatenate files, stripping duplicate PHP tags and namespace/use statements
+        $combined = "<?php\n\n";
+        foreach ($files as $file) {
+            $content = file_get_contents($file);
+            assert(is_string($content));
+            // Strip PHP open tags
+            $content = preg_replace('/^<\?php\s*/', '', $content);
+            assert(is_string($content));
+            // Strip namespace declarations
+            $content = preg_replace('/^namespace\s+[^;]+;\s*$/m', '', $content);
+            // Strip use statements
+            $content = preg_replace('/^use\s+[^;]+;\s*$/m', '', $content);
+            // Strip declare statements
+            $content = preg_replace('/^declare\s*\([^)]+\)\s*;\s*$/m', '', $content);
+            assert(is_string($content));
+            $combined .= "// --- " . basename($file) . " ---\n";
+            $combined .= $content . "\n";
+        }
+
+        $combinedPath = "{$tmpDir}/" . str_replace(' ', '_', $name) . '.php';
+        file_put_contents($combinedPath, $combined);
+
+        $output = [];
+        $exitCode = 0;
+        exec("{$picoHP} build {$combinedPath} 2>&1", $output, $exitCode);
+
+        $fileCount = count($files);
+        if ($exitCode === 0) {
+            $groupPass++;
+            echo "  ✅ {$name} ({$fileCount} files)\n";
+        } else {
+            $groupFail++;
+            $errorMsg = extractError($output);
+            echo "  ❌ {$name} ({$fileCount} files)\n";
+            if ($verbose) {
+                echo "     {$errorMsg}\n";
+            }
+        }
     }
+
+    echo "\n━━━ Multi-file summary ━━━\n";
+    $groupTotal = $groupPass + $groupFail;
+    echo "  Groups: {$groupTotal}  Pass: {$groupPass}  Fail: {$groupFail}\n";
+}
+
+/**
+ * @param array<string> $output
+ */
+function extractError(array $output): string
+{
+    $errorMsg = '';
+    foreach ($output as $line) {
+        $line = trim($line);
+        if ($line !== '' && !str_starts_with($line, '#') && !str_starts_with($line, 'at ')) {
+            $errorMsg = $line;
+            break;
+        }
+    }
+    if (preg_match('/unknown node type.*: (.+)/', $errorMsg, $m)) {
+        $errorMsg = 'unsupported: ' . basename($m[1]);
+    } elseif (preg_match('/function (.+) not found/', $errorMsg, $m)) {
+        $errorMsg = 'missing function: ' . $m[1];
+    } elseif (preg_match('/assert\((.+)\)/', $errorMsg, $m)) {
+        $errorMsg = 'assert: ' . substr($m[1], 0, 60);
+    }
+    return $errorMsg;
 }


### PR DESCRIPTION
## Summary
- Add `--multi` flag to `self-host-check.php` for testing related file groups
- Concatenates multiple files, strips namespace/use/declare, and compiles as one unit
- 6 file groups defined covering the most important compiler subsystems

## Current results
```
✅ picoHP PassInterface + IRLine (2 files)
❌ LLVM Value hierarchy (9 files) — needs enums (BaseType)
❌ LLVM IR infrastructure (2 files) — needs traits
❌ Symbol table (3 files) — needs Illuminate dep removed
❌ php-parser Node base (2 files) — needs enums
❌ picoHP ClassMetadata + Symbol (2 files) — needs external type deps
```

## Blockers identified
1. **Enums** — BaseType is used by nearly every class
2. **Traits** — BasicBlock uses a trait
3. **External dependencies** — Scope uses Illuminate\Support\Arr

Partial #88

## Test plan
- [x] All 75 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)