### PR TITLE
feat: add strval() built-in, unblocking multi-file Value compilation

### DIFF
--- a/app/PicoHP/LLVM/Builder.php
+++ b/app/PicoHP/LLVM/Builder.php
@@ -32,6 +32,7 @@ class Builder
         $this->addLine('declare ptr @pico_string_concat(ptr, ptr)');
         $this->addLine('declare i32 @pico_rt_version()');
         $this->addLine('declare i32 @pico_string_len(ptr)');
+        $this->addLine('declare ptr @pico_int_to_string(i32)');
         $this->addLine('declare i32 @pico_string_starts_with(ptr, ptr)');
         $this->addLine('declare i32 @pico_string_contains(ptr, ptr)');
         $this->addLine('declare ptr @pico_string_substr(ptr, i32, i32)');

--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -567,6 +567,12 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                 $arrVal = $this->buildExpr($expr->args[0]->value);
                 return $this->builder->createArrayLen($arrVal);
             }
+            if ($funcName === 'strval') {
+                assert(count($expr->args) === 1);
+                assert($expr->args[0] instanceof \PhpParser\Node\Arg);
+                $val = $this->buildExpr($expr->args[0]->value);
+                return $this->builder->createCall('pico_int_to_string', [$val], BaseType::STRING);
+            }
             if ($funcName === 'strlen') {
                 assert(count($expr->args) === 1);
                 assert($expr->args[0] instanceof \PhpParser\Node\Arg);

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -495,6 +495,9 @@ class SemanticAnalysisPass implements PassInterface
             if ($funcName === 'str_starts_with' || $funcName === 'str_contains') {
                 return PicoType::fromString('bool');
             }
+            if ($funcName === 'strval') {
+                return PicoType::fromString('string');
+            }
             if ($funcName === 'substr' || $funcName === 'trim' || $funcName === 'str_repeat') {
                 return PicoType::fromString('string');
             }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -28,6 +28,13 @@ pub extern "C" fn pico_string_concat(a: *const c_char, b: *const c_char) -> *mut
 // ---------------------------------------------------------------------------
 
 #[no_mangle]
+pub extern "C" fn pico_int_to_string(val: i32) -> *mut c_char {
+    let s = val.to_string();
+    let c_str = std::ffi::CString::new(s).unwrap();
+    c_str.into_raw()
+}
+
+#[no_mangle]
 pub extern "C" fn pico_string_len(s: *const c_char) -> i32 {
     let s = unsafe { CStr::from_ptr(s) };
     s.to_bytes().len() as i32


### PR DESCRIPTION
## Summary
- Add `pico_int_to_string` runtime function
- Wire up `strval()` as a built-in PHP function
- Unblocks multi-file compilation of LLVM Value core group

## Multi-file milestone
```
✅ LLVM Value core - BaseType + ValueAbstract + NullConstant + Param (4 files)
✅ picoHP PassInterface + IRLine (2 files)
```

First time the compiler compiles its own enum + abstract class + concrete subclasses together.

Partial #69, partial #88

## Test plan
- [x] All 76 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)