### PR TITLE
feat: add try/catch/finally exception handling

### DIFF
--- a/app/Commands/Build.php
+++ b/app/Commands/Build.php
@@ -111,7 +111,7 @@ class Build extends Command
             file_put_contents($astWithSymbolOutput, json_encode($transformedAst, JSON_PRETTY_PRINT));
         }
 
-        $pass = new IRGenerationPass($transformedAst, $semanticPass->getClassRegistry(), $semanticPass->getEnumRegistry());
+        $pass = new IRGenerationPass($transformedAst, $semanticPass->getClassRegistry(), $semanticPass->getEnumRegistry(), $semanticPass->getTypeIdMap());
         $pass->exec();
 
         $f = fopen($llvmIRoutput, 'w');

--- a/app/PicoHP/LLVM/BasicBlock.php
+++ b/app/PicoHP/LLVM/BasicBlock.php
@@ -44,8 +44,8 @@ class BasicBlock implements NodeInterface
     public function verify(): void
     {
         $lastLine = end($this->lines);
-        if ($lastLine === false || !Str::startsWith(trim($lastLine->toString()), ['ret', 'br'])) {
-            throw new \RuntimeException("Basic block {$this->name} must end with ret or br");
+        if ($lastLine === false || !Str::startsWith(trim($lastLine->toString()), ['ret', 'br', 'unreachable'])) {
+            throw new \RuntimeException("Basic block {$this->name} must end with ret, br, or unreachable");
         }
     }
 }

--- a/app/PicoHP/LLVM/Builder.php
+++ b/app/PicoHP/LLVM/Builder.php
@@ -41,6 +41,16 @@ class Builder
         $this->addLine('declare ptr @pico_string_replace(ptr, ptr, ptr)');
         $this->addLine('declare ptr @picohp_object_alloc(i64, i32)');
         $this->addLine();
+        $this->addLine('; exception handling');
+        $this->addLine('declare i32 @setjmp(ptr)');
+        $this->addLine('declare void @picohp_eh_push(ptr)');
+        $this->addLine('declare void @picohp_eh_pop()');
+        $this->addLine('declare void @picohp_throw(ptr, i32)');
+        $this->addLine('declare ptr @picohp_eh_get_exception()');
+        $this->addLine('declare i32 @picohp_eh_get_type_id()');
+        $this->addLine('declare i32 @picohp_eh_matches_type(i32)');
+        $this->addLine('declare void @picohp_eh_clear()');
+        $this->addLine();
         $this->addLine('; array runtime');
         $this->addLine('declare ptr @pico_array_new()');
         $this->addLine('declare i32 @pico_array_len(ptr)');
@@ -328,6 +338,78 @@ class Builder
     public function createRetVoid(): void
     {
         $this->addLine('ret void', 1);
+    }
+
+    // -- exception handling --------------------------------------------------
+
+    /**
+     * Allocate a jmp_buf on the stack (48 x i32 = 192 bytes on macOS arm64).
+     */
+    public function createJmpBufAlloca(): ValueAbstract
+    {
+        $resultVal = new AllocaInst('jmpbuf', BaseType::PTR);
+        $this->addLine("{$resultVal->render()} = alloca [48 x i32], align 8", 1);
+        return $resultVal;
+    }
+
+    /**
+     * Push the jmp_buf onto the exception handler stack, then call setjmp.
+     * Returns i32: 0 = normal entry, nonzero = exception caught.
+     */
+    public function createSetjmp(ValueAbstract $jmpBuf): ValueAbstract
+    {
+        $this->addLine("call void @picohp_eh_push(ptr {$jmpBuf->render()})", 1);
+        $resultVal = new Instruction('setjmp', BaseType::INT);
+        $this->addLine("{$resultVal->render()} = call i32 @setjmp(ptr {$jmpBuf->render()})", 1);
+        return $resultVal;
+    }
+
+    /**
+     * Pop the current exception handler (normal exit from try block).
+     */
+    public function createEhPop(): void
+    {
+        $this->addLine('call void @picohp_eh_pop()', 1);
+    }
+
+    /**
+     * Throw an exception object with a given type_id.
+     */
+    public function createThrow(ValueAbstract $exceptionPtr, int $typeId): void
+    {
+        $this->addLine("call void @picohp_throw(ptr {$exceptionPtr->render()}, i32 {$typeId})", 1);
+        $this->addLine('unreachable', 1);
+    }
+
+    /**
+     * Get the current in-flight exception object pointer.
+     */
+    public function createEhGetException(): ValueAbstract
+    {
+        $resultVal = new Instruction('eh_exception', BaseType::PTR);
+        $this->addLine("{$resultVal->render()} = call ptr @picohp_eh_get_exception()", 1);
+        return $resultVal;
+    }
+
+    /**
+     * Check if the current exception matches a given type_id.
+     * Returns i1 (bool).
+     */
+    public function createEhMatchesType(int $typeId): ValueAbstract
+    {
+        $callResult = new Instruction('eh_match', BaseType::INT);
+        $this->addLine("{$callResult->render()} = call i32 @picohp_eh_matches_type(i32 {$typeId})", 1);
+        $boolResult = new Instruction('eh_match_bool', BaseType::BOOL);
+        $this->addLine("{$boolResult->render()} = icmp ne i32 {$callResult->render()}, 0", 1);
+        return $boolResult;
+    }
+
+    /**
+     * Clear the current exception state (after it's been handled).
+     */
+    public function createEhClear(): void
+    {
+        $this->addLine('call void @picohp_eh_clear()', 1);
     }
 
     // public function createGlobal(string $name, ValueAbstract $val): ValueAbstract

--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -29,23 +29,62 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
     /** @var array<string, EnumMetadata> */
     protected array $enumRegistry = [];
 
+    /** @var array<string, int> class name => type_id */
+    protected array $typeIdMap = [];
+
     /**
      * @param array<\PhpParser\Node> $stmts
      * @param array<string, ClassMetadata> $classRegistry
      * @param array<string, EnumMetadata> $enumRegistry
+     * @param array<string, int> $typeIdMap
      */
-    public function __construct(array $stmts, array $classRegistry = [], array $enumRegistry = [])
+    public function __construct(array $stmts, array $classRegistry = [], array $enumRegistry = [], array $typeIdMap = [])
     {
         $this->module = new Module("test_module");
         $this->builder = $this->module->getBuilder();
         $this->stmts = $stmts;
         $this->classRegistry = $classRegistry;
         $this->enumRegistry = $enumRegistry;
+        $this->typeIdMap = $typeIdMap;
     }
 
     public function exec(): void
     {
+        $this->emitBuiltinExceptionClass();
         $this->buildStmts($this->stmts);
+    }
+
+    protected function emitBuiltinExceptionClass(): void
+    {
+        if (!isset($this->classRegistry['Exception'])) {
+            return;
+        }
+        // Exception struct: { ptr message }
+        $this->module->addLine(new \App\PicoHP\LLVM\IRLine('%struct.Exception = type { ptr }'));
+
+        // Exception___construct(ptr %this, ptr %message)
+        $ctorFunc = $this->module->addFunction('Exception___construct', new \App\PicoHP\PicoType(BaseType::VOID), [
+            new \App\PicoHP\PicoType(BaseType::PTR),
+            new \App\PicoHP\PicoType(BaseType::STRING),
+        ]);
+        $bb = $ctorFunc->addBasicBlock('entry');
+        $this->builder->setInsertPoint($bb);
+        $thisParam = new Param(0, BaseType::PTR);
+        $msgParam = new Param(1, BaseType::STRING);
+        $fieldPtr = $this->builder->createStructGEP('Exception', $thisParam, 0, BaseType::STRING);
+        $this->builder->createStore($msgParam, $fieldPtr);
+        $this->builder->createRetVoid();
+
+        // Exception_getMessage(ptr %this) -> ptr
+        $getMessageFunc = $this->module->addFunction('Exception_getMessage', new \App\PicoHP\PicoType(BaseType::STRING), [
+            new \App\PicoHP\PicoType(BaseType::PTR),
+        ]);
+        $bb = $getMessageFunc->addBasicBlock('entry');
+        $this->builder->setInsertPoint($bb);
+        $thisParam = new Param(0, BaseType::PTR);
+        $fieldPtr = $this->builder->createStructGEP('Exception', $thisParam, 0, BaseType::STRING);
+        $msgVal = $this->builder->createLoad($fieldPtr);
+        $this->builder->createInstruction('ret', [$msgVal], false);
     }
 
     /**
@@ -376,6 +415,8 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Use_) {
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Namespace_) {
             $this->buildStmts($stmt->stmts);
+        } elseif ($stmt instanceof \PhpParser\Node\Stmt\TryCatch) {
+            $this->buildTryCatch($stmt, $pData);
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\InlineHTML) {
             // TODO: create string constant?
         } else {
@@ -796,6 +837,27 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                 return $globalPtr;
             }
             return $this->builder->createLoad($globalPtr);
+        } elseif ($expr instanceof \PhpParser\Node\Expr\Throw_) {
+            // throw new ClassName(args...)
+            assert($expr->expr instanceof \PhpParser\Node\Expr\New_);
+            $newExpr = $expr->expr;
+            assert($newExpr->class instanceof \PhpParser\Node\Name);
+            $className = $newExpr->class->toString();
+            $classMeta = $this->classRegistry[$className];
+            $objPtr = $this->builder->createObjectAlloc($className);
+            // Call constructor if it exists
+            if (isset($classMeta->methods['__construct'])) {
+                $ctorSymbol = $classMeta->methods['__construct'];
+                $args = $this->buildArgsWithDefaults($newExpr->args, $ctorSymbol);
+                /** @var array<ValueAbstract> $allArgs */
+                $allArgs = array_merge([$objPtr], $args);
+                $ctorOwner = $classMeta->methodOwner['__construct'] ?? $className;
+                $qualifiedName = "{$ctorOwner}___construct";
+                $this->builder->createCall($qualifiedName, $allArgs, BaseType::VOID);
+            }
+            $typeId = $this->typeIdMap[$className] ?? 0;
+            $this->builder->createThrow($objPtr, $typeId);
+            return new Void_();
         } else {
             throw new \Exception("unknown node type in expr: " . get_class($expr));
         }
@@ -983,5 +1045,140 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             $type = $pData->getSymbol()->type;
             $this->builder->createStore(new Param($count++, $type->toBase()), $pData->getValue());
         }
+    }
+
+    /**
+     * Get all type_ids that should match a catch clause for a given class name.
+     * Includes the class itself and all subclasses that have type_ids.
+     *
+     * @return array<int>
+     */
+    protected function getMatchingTypeIds(string $className): array
+    {
+        $ids = [];
+        foreach ($this->typeIdMap as $name => $id) {
+            if ($this->isSubclassOf($name, $className)) {
+                $ids[] = $id;
+            }
+        }
+        return $ids;
+    }
+
+    protected function isSubclassOf(string $className, string $parentName): bool
+    {
+        if ($className === $parentName) {
+            return true;
+        }
+        $meta = $this->classRegistry[$className] ?? null;
+        if ($meta === null || $meta->parentName === null) {
+            return false;
+        }
+        return $this->isSubclassOf($meta->parentName, $parentName);
+    }
+
+    protected function buildTryCatch(\PhpParser\Node\Stmt\TryCatch $stmt, PicoHPData $pData): void
+    {
+        assert($this->currentFunction !== null);
+        $currentFunction = $this->currentFunction;
+        $count = $pData->mycount;
+
+        $hasCatches = count($stmt->catches) > 0;
+
+        // Create basic blocks
+        $tryBB = $currentFunction->addBasicBlock("try{$count}");
+        $catchDispatchBB = $hasCatches ? $currentFunction->addBasicBlock("catch_dispatch{$count}") : null;
+        $finallyBB = $stmt->finally !== null ? $currentFunction->addBasicBlock("finally{$count}") : null;
+        $endBB = $currentFunction->addBasicBlock("try_end{$count}");
+
+        $tryLabel = new Label($tryBB->getName());
+        $finallyLabel = $finallyBB !== null ? new Label($finallyBB->getName()) : null;
+        $endLabel = new Label($endBB->getName());
+
+        // After try/catch: where to go
+        $continueLabel = $finallyLabel ?? $endLabel;
+
+        // Allocate jmp_buf and call setjmp
+        $jmpBuf = $this->builder->createJmpBufAlloca();
+        $setjmpRet = $this->builder->createSetjmp($jmpBuf);
+        $isException = $this->builder->createInstruction('icmp ne', [$setjmpRet, new Constant(0, BaseType::INT)], resultType: BaseType::BOOL);
+        $exceptionTarget = $catchDispatchBB !== null ? new Label($catchDispatchBB->getName()) : $continueLabel;
+        $this->builder->createBranch([$isException, $exceptionTarget, $tryLabel]);
+
+        // -- try body --
+        $this->builder->setInsertPoint($tryBB);
+        $this->buildStmts($stmt->stmts);
+        $this->builder->createEhPop();
+        $this->builder->createBranch([$continueLabel]);
+
+        // -- catch dispatch --
+        if ($catchDispatchBB !== null) {
+            $this->builder->setInsertPoint($catchDispatchBB);
+            $this->builder->createEhPop();
+
+            $catchCount = count($stmt->catches);
+            /** @var array<\App\PicoHP\LLVM\BasicBlock> $catchBodyBBs */
+            $catchBodyBBs = [];
+            for ($i = 0; $i < $catchCount; $i++) {
+                $catchBodyBBs[] = $currentFunction->addBasicBlock("catch{$count}_{$i}");
+            }
+
+            // Emit type-check chain
+            for ($i = 0; $i < $catchCount; $i++) {
+                $catch = $stmt->catches[$i];
+                assert(count($catch->types) > 0);
+                $catchTypeName = $catch->types[0]->toString();
+                $catchBodyLabel = new Label($catchBodyBBs[$i]->getName());
+
+                if ($i + 1 < $catchCount) {
+                    $nextCheckBB = $currentFunction->addBasicBlock("catch_check{$count}_" . ($i + 1));
+                    $nextCheckLabel = new Label($nextCheckBB->getName());
+                } else {
+                    $nextCheckBB = null;
+                    $nextCheckLabel = $continueLabel;
+                }
+
+                $matchingIds = $this->getMatchingTypeIds($catchTypeName);
+                if (count($matchingIds) === 1) {
+                    $matches = $this->builder->createEhMatchesType($matchingIds[0]);
+                } else {
+                    $matches = $this->builder->createEhMatchesType($matchingIds[0]);
+                    for ($j = 1; $j < count($matchingIds); $j++) {
+                        $nextMatch = $this->builder->createEhMatchesType($matchingIds[$j]);
+                        $matches = $this->builder->createInstruction('or', [$matches, $nextMatch], resultType: BaseType::BOOL);
+                    }
+                }
+                $this->builder->createBranch([$matches, $catchBodyLabel, $nextCheckLabel]);
+
+                if ($nextCheckBB !== null) {
+                    $this->builder->setInsertPoint($nextCheckBB);
+                }
+            }
+
+            // Emit catch body blocks
+            for ($i = 0; $i < $catchCount; $i++) {
+                $catch = $stmt->catches[$i];
+                $this->builder->setInsertPoint($catchBodyBBs[$i]);
+                if ($catch->var !== null) {
+                    $exceptionPtr = $this->builder->createEhGetException();
+                    $catchVarPData = PicoHPData::getPData($catch->var);
+                    $catchVarPtr = $catchVarPData->getValue();
+                    $this->builder->createStore($exceptionPtr, $catchVarPtr);
+                }
+                $this->builder->createEhClear();
+                $this->buildStmts($catch->stmts);
+                $this->builder->createBranch([$continueLabel]);
+            }
+        }
+
+        // -- finally block --
+        if ($stmt->finally !== null) {
+            /** @var \App\PicoHP\LLVM\BasicBlock $finallyBB */
+            $this->builder->setInsertPoint($finallyBB);
+            $this->buildStmts($stmt->finally->stmts);
+            $this->builder->createBranch([$endLabel]);
+        }
+
+        // -- end --
+        $this->builder->setInsertPoint($endBB);
     }
 }

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -56,11 +56,42 @@ class SemanticAnalysisPass implements PassInterface
         return $this->enumRegistry;
     }
 
+    /** @var int */
+    protected int $nextTypeId = 1;
+
+    /** @var array<string, int> class name => type_id for exception type matching */
+    protected array $typeIdMap = [];
+
+    /**
+     * @return array<string, int>
+     */
+    public function getTypeIdMap(): array
+    {
+        return $this->typeIdMap;
+    }
+
     public function exec(): void
     {
+        $this->registerBuiltinClasses();
         $this->registerClasses($this->ast);
         $this->registerFunctions($this->ast);
         $this->resolveStmts($this->ast);
+    }
+
+    protected function registerBuiltinClasses(): void
+    {
+        $exceptionMeta = new ClassMetadata('Exception');
+        $exceptionMeta->addProperty('message', PicoType::fromString('string'));
+        $getMessageSymbol = new \App\PicoHP\SymbolTable\Symbol('getMessage', PicoType::fromString('string'), func: true);
+        $exceptionMeta->methods['getMessage'] = $getMessageSymbol;
+        $exceptionMeta->methodOwner['getMessage'] = 'Exception';
+        $ctorSymbol = new \App\PicoHP\SymbolTable\Symbol('__construct', PicoType::fromString('void'), func: true);
+        $ctorSymbol->params = [PicoType::fromString('string')];
+        $ctorSymbol->paramNames = [0 => 'message'];
+        $exceptionMeta->methods['__construct'] = $ctorSymbol;
+        $exceptionMeta->methodOwner['__construct'] = 'Exception';
+        $this->classRegistry['Exception'] = $exceptionMeta;
+        $this->typeIdMap['Exception'] = $this->nextTypeId++;
     }
 
     /**
@@ -89,6 +120,10 @@ class SemanticAnalysisPass implements PassInterface
                     $parentName = $stmt->extends->toString();
                     assert(isset($this->classRegistry[$parentName]), "parent class {$parentName} not found");
                     $classMeta->inheritFrom($this->classRegistry[$parentName]);
+                }
+                // Assign type_id if this class is throwable (extends Exception hierarchy)
+                if ($this->isExceptionClass($className)) {
+                    $this->typeIdMap[$className] = $this->nextTypeId++;
                 }
                 foreach ($stmt->stmts as $classStmt) {
                     if ($classStmt instanceof \PhpParser\Node\Stmt\Property) {
@@ -181,6 +216,53 @@ class SemanticAnalysisPass implements PassInterface
                 }
             }
         }
+    }
+
+    /**
+     * Check if a class is an exception class (is or extends Exception).
+     */
+    protected function isExceptionClass(string $className): bool
+    {
+        if ($className === 'Exception') {
+            return true;
+        }
+        $meta = $this->classRegistry[$className] ?? null;
+        if ($meta === null) {
+            return false;
+        }
+        if ($meta->parentName !== null) {
+            return $this->isExceptionClass($meta->parentName);
+        }
+        return false;
+    }
+
+    /**
+     * Get all type_ids that should match a catch clause for a given class.
+     * Includes the class itself and all its descendants.
+     *
+     * @return array<int>
+     */
+    public function getMatchingTypeIds(string $className): array
+    {
+        $ids = [];
+        foreach ($this->typeIdMap as $name => $id) {
+            if ($this->isSubclassOf($name, $className)) {
+                $ids[] = $id;
+            }
+        }
+        return $ids;
+    }
+
+    protected function isSubclassOf(string $className, string $parentName): bool
+    {
+        if ($className === $parentName) {
+            return true;
+        }
+        $meta = $this->classRegistry[$className] ?? null;
+        if ($meta === null || $meta->parentName === null) {
+            return false;
+        }
+        return $this->isSubclassOf($meta->parentName, $parentName);
     }
 
     private function typeFromNode(\PhpParser\Node\Identifier|\PhpParser\Node\NullableType|\PhpParser\Node\Name $node): PicoType
@@ -347,6 +429,30 @@ class SemanticAnalysisPass implements PassInterface
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\EnumCase) {
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Use_) {
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Interface_) {
+        } elseif ($stmt instanceof \PhpParser\Node\Stmt\TryCatch) {
+            $this->resolveStmts($stmt->stmts);
+            foreach ($stmt->catches as $catch) {
+                assert(count($catch->types) > 0);
+                $catchTypeName = $catch->types[0]->toString();
+                assert(isset($this->classRegistry[$catchTypeName]), "catch class {$catchTypeName} not found");
+                if ($catch->var !== null) {
+                    assert(is_string($catch->var->name));
+                    $catchPData = $this->getPicoData($catch->var);
+                    $existing = $this->symbolTable->lookupCurrentScope($catch->var->name);
+                    if ($existing !== null) {
+                        $catchPData->symbol = $existing;
+                    } else {
+                        $catchPData->symbol = $this->symbolTable->addSymbol(
+                            $catch->var->name,
+                            PicoType::object($catchTypeName)
+                        );
+                    }
+                }
+                $this->resolveStmts($catch->stmts);
+            }
+            if ($stmt->finally !== null) {
+                $this->resolveStmts($stmt->finally->stmts);
+            }
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Namespace_) {
             $this->resolveStmts($stmt->stmts);
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\InlineHTML) {
@@ -593,6 +699,9 @@ class SemanticAnalysisPass implements PassInterface
             $classMeta = $this->classRegistry[$className];
             assert(isset($classMeta->methods[$methodName]), "method {$methodName} not found on {$className}");
             return $classMeta->methods[$methodName]->type;
+        } elseif ($expr instanceof \PhpParser\Node\Expr\Throw_) {
+            $this->resolveExpr($expr->expr);
+            return PicoType::fromString('void');
         } else {
             $line = $this->getLine($expr);
             throw new \Exception("line {$line}, unknown node type in expr resolver: " . get_class($expr));

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -155,6 +155,112 @@ pub extern "C" fn pico_string_trim(s: *const c_char) -> *mut c_char {
 }
 
 // ---------------------------------------------------------------------------
+// Exception handling (setjmp/longjmp based)
+// ---------------------------------------------------------------------------
+
+struct ExceptionState {
+    /// Pointer to the current in-flight exception object (null if none).
+    exception_ptr: *mut u8,
+    /// The type_id of the current in-flight exception (for catch-clause matching).
+    exception_type_id: u32,
+    /// Stack of jmp_buf pointers — each try block pushes one.
+    handler_stack: Vec<*mut u8>,
+}
+
+static mut EXCEPTION_STATE: ExceptionState = ExceptionState {
+    exception_ptr: std::ptr::null_mut(),
+    exception_type_id: 0,
+    handler_stack: Vec::new(),
+};
+
+extern "C" {
+    fn longjmp(env: *mut u8, val: i32) -> !;
+}
+
+/// Push a jmp_buf pointer onto the exception handler stack.
+/// Called right before setjmp() in the generated IR.
+#[no_mangle]
+pub extern "C" fn picohp_eh_push(jmp_buf_ptr: *mut u8) {
+    unsafe {
+        EXCEPTION_STATE.handler_stack.push(jmp_buf_ptr);
+    }
+}
+
+/// Pop the top jmp_buf from the handler stack (normal exit from try block).
+#[no_mangle]
+pub extern "C" fn picohp_eh_pop() {
+    unsafe {
+        EXCEPTION_STATE.handler_stack.pop();
+    }
+}
+
+/// Throw an exception: store the object pointer and type_id, then longjmp.
+/// If no handler is on the stack, prints an error and aborts.
+#[no_mangle]
+pub extern "C" fn picohp_throw(exception_ptr: *mut u8, type_id: u32) {
+    unsafe {
+        EXCEPTION_STATE.exception_ptr = exception_ptr;
+        EXCEPTION_STATE.exception_type_id = type_id;
+        if let Some(&jmp_buf_ptr) = EXCEPTION_STATE.handler_stack.last() {
+            longjmp(jmp_buf_ptr, 1);
+        } else {
+            eprintln!("Fatal error: Uncaught exception (type_id={})", type_id);
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Get the current in-flight exception object pointer.
+#[no_mangle]
+pub extern "C" fn picohp_eh_get_exception() -> *mut u8 {
+    unsafe { EXCEPTION_STATE.exception_ptr }
+}
+
+/// Get the type_id of the current in-flight exception.
+#[no_mangle]
+pub extern "C" fn picohp_eh_get_type_id() -> u32 {
+    unsafe { EXCEPTION_STATE.exception_type_id }
+}
+
+/// Check if exception type_id matches a given type_id or any of its ancestors.
+/// The ancestor_ids array is a null-terminated list of type_ids for the catch class
+/// and all its descendants. For simplicity, we just check if exception_type_id
+/// matches the given type_id.
+#[no_mangle]
+pub extern "C" fn picohp_eh_matches_type(catch_type_id: u32) -> i32 {
+    unsafe {
+        if EXCEPTION_STATE.exception_type_id == catch_type_id {
+            return 1;
+        }
+        0
+    }
+}
+
+/// Check if exception type matches any type in a list.
+/// type_ids is a pointer to an array of u32, count is the length.
+#[no_mangle]
+pub extern "C" fn picohp_eh_matches_any(type_ids: *const u32, count: u32) -> i32 {
+    unsafe {
+        let slice = std::slice::from_raw_parts(type_ids, count as usize);
+        for &tid in slice {
+            if EXCEPTION_STATE.exception_type_id == tid {
+                return 1;
+            }
+        }
+        0
+    }
+}
+
+/// Clear the current exception state (after it has been handled).
+#[no_mangle]
+pub extern "C" fn picohp_eh_clear() {
+    unsafe {
+        EXCEPTION_STATE.exception_ptr = std::ptr::null_mut();
+        EXCEPTION_STATE.exception_type_id = 0;
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Object allocation
 // ---------------------------------------------------------------------------
 

--- a/tests/Feature/ExceptionTest.php
+++ b/tests/Feature/ExceptionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles basic try/catch', function () {
+    $file = 'tests/programs/exceptions/basic_try_catch.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles throw from nested function calls', function () {
+    $file = 'tests/programs/exceptions/throw_in_function.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles try/catch/finally', function () {
+    $file = 'tests/programs/exceptions/finally.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles multiple catch clauses', function () {
+    $file = 'tests/programs/exceptions/multiple_catch.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles custom exception with extra properties', function () {
+    $file = 'tests/programs/exceptions/custom_exception.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/Unit/LLVMValueTest.php
+++ b/tests/Unit/LLVMValueTest.php
@@ -56,7 +56,7 @@ it('throws an exception on an invalid block', function () {
     $builder->setInsertPoint($bb);
     $builder->createInstruction('add', [new Constant(1, BaseType::INT), new Constant(2, BaseType::INT)]);
     $bb->getLines();
-})->throws(\RuntimeException::class, 'Basic block entry must end with ret or br');
+})->throws(\RuntimeException::class, 'Basic block entry must end with ret, br, or unreachable');
 
 it('can create a global value', function () {
     $global = new Global_('my_global', BaseType::INT);

--- a/tests/programs/exceptions/basic_try_catch.php
+++ b/tests/programs/exceptions/basic_try_catch.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+class MyException extends Exception
+{
+}
+
+function riskyOperation(int $x): string
+{
+    if ($x === 0) {
+        throw new MyException('division by zero');
+    }
+    return "result: " . strval($x);
+}
+
+try {
+    echo riskyOperation(5) . "\n";
+} catch (MyException $e) {
+    echo "caught: " . $e->getMessage() . "\n";
+}
+
+try {
+    echo riskyOperation(0) . "\n";
+} catch (MyException $e) {
+    echo "caught: " . $e->getMessage() . "\n";
+}
+
+echo "done\n";

--- a/tests/programs/exceptions/custom_exception.php
+++ b/tests/programs/exceptions/custom_exception.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+class AppException extends Exception
+{
+    private int $errorCode;
+
+    public function __construct(string $message, int $errorCode)
+    {
+        parent::__construct($message);
+        $this->errorCode = $errorCode;
+    }
+
+    public function getErrorCode(): int
+    {
+        return $this->errorCode;
+    }
+}
+
+try {
+    throw new AppException('not found', 404);
+} catch (AppException $e) {
+    echo "AppException: " . $e->getMessage() . " (code " . strval($e->getErrorCode()) . ")\n";
+}
+
+echo "done\n";

--- a/tests/programs/exceptions/finally.php
+++ b/tests/programs/exceptions/finally.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+class MyException extends Exception
+{
+}
+
+function maybeThrow(bool $doThrow): string
+{
+    if ($doThrow) {
+        throw new MyException('oops');
+    }
+    return "ok";
+}
+
+try {
+    echo maybeThrow(false) . "\n";
+} catch (MyException $e) {
+    echo "catch\n";
+} finally {
+    echo "finally\n";
+}
+
+try {
+    echo maybeThrow(true) . "\n";
+} catch (MyException $e) {
+    echo "caught: " . $e->getMessage() . "\n";
+} finally {
+    echo "cleanup\n";
+}
+
+echo "done\n";

--- a/tests/programs/exceptions/multiple_catch.php
+++ b/tests/programs/exceptions/multiple_catch.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+class MyException extends Exception
+{
+}
+
+class ChildException extends MyException
+{
+}
+
+function throwBase(): void
+{
+    throw new MyException('base error');
+}
+
+function throwChild(): void
+{
+    throw new ChildException('child error');
+}
+
+try {
+    throwChild();
+} catch (ChildException $e) {
+    echo "ChildException: " . $e->getMessage() . "\n";
+} catch (MyException $e) {
+    echo "MyException: " . $e->getMessage() . "\n";
+}
+
+try {
+    throwBase();
+} catch (ChildException $e) {
+    echo "ChildException: " . $e->getMessage() . "\n";
+} catch (MyException $e) {
+    echo "MyException: " . $e->getMessage() . "\n";
+}
+
+echo "done\n";

--- a/tests/programs/exceptions/throw_in_function.php
+++ b/tests/programs/exceptions/throw_in_function.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+class MyException extends Exception
+{
+}
+
+function inner(): string
+{
+    throw new MyException('from inner');
+}
+
+function outer(): string
+{
+    return inner() . " wrapped";
+}
+
+try {
+    echo outer() . "\n";
+} catch (MyException $e) {
+    echo "caught: " . $e->getMessage() . "\n";
+}
+
+echo "after\n";


### PR DESCRIPTION
## Summary
- Implement exception handling using setjmp/longjmp approach
- Add built-in `Exception` class with `message` property and `getMessage()` method
- Support `throw`, `try/catch`, `try/catch/finally`, multiple catch clauses, exception class inheritance, custom exceptions with extra properties
- 5 new tests, 82 total passing, zero regressions

## Implementation
- **Runtime** (`runtime/src/lib.rs`): Global exception handler stack (jmp_buf pointers), `picohp_throw`/`picohp_eh_push`/`picohp_eh_pop`/`picohp_eh_get_exception`/`picohp_eh_matches_type`/`picohp_eh_clear`
- **Builder** (`Builder.php`): `createJmpBufAlloca`, `createSetjmp`, `createThrow`, `createEhMatchesType`, `createEhGetException`, `createEhClear`, `createEhPop`
- **Semantic analysis**: Built-in `Exception` class registration, type_id assignment for throwable classes, inheritance-aware type matching, `TryCatch`/`Throw_` resolution
- **IR generation**: `buildTryCatch` with setjmp-based dispatch, type-filtered catch chains, finally blocks

## Test plan
- [x] `basic_try_catch.php` — throw/catch within function
- [x] `throw_in_function.php` — exception propagates through nested calls
- [x] `finally.php` — finally block executes in both normal and exception paths
- [x] `multiple_catch.php` — child exception caught by specific clause, parent by general
- [x] `custom_exception.php` — exception class with extra properties and parent::__construct
- [x] All 82 tests pass (77 existing + 5 new)
- [x] PHPStan clean, Pint clean

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)