### PR TITLE
feat: support int|float union type widening

### DIFF
--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -929,12 +929,17 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
         $result = [];
         for ($i = 0; $i < $paramCount; $i++) {
             if (isset($argsByPos[$i])) {
-                $result[] = $this->buildExpr($argsByPos[$i]);
+                $val = $this->buildExpr($argsByPos[$i]);
             } elseif (isset($funcSymbol->defaults[$i])) {
-                $result[] = $this->buildDefaultValue($funcSymbol->defaults[$i]);
+                $val = $this->buildDefaultValue($funcSymbol->defaults[$i]);
             } else {
                 throw new \RuntimeException("missing argument {$i} for function {$funcSymbol->name} with no default");
             }
+            // Coerce int to float when param expects float (e.g. int|float union widened to float)
+            if ($val->getType() === BaseType::INT && $funcSymbol->params[$i]->toBase() === BaseType::FLOAT) {
+                $val = $this->builder->createSiToFp($val);
+            }
+            $result[] = $val;
         }
         return $result;
     }

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -127,7 +127,7 @@ class SemanticAnalysisPass implements PassInterface
                 }
                 foreach ($stmt->stmts as $classStmt) {
                     if ($classStmt instanceof \PhpParser\Node\Stmt\Property) {
-                        assert($classStmt->type instanceof \PhpParser\Node\Identifier || $classStmt->type instanceof \PhpParser\Node\NullableType || $classStmt->type instanceof \PhpParser\Node\Name);
+                        assert($classStmt->type instanceof \PhpParser\Node\Identifier || $classStmt->type instanceof \PhpParser\Node\NullableType || $classStmt->type instanceof \PhpParser\Node\Name || $classStmt->type instanceof \PhpParser\Node\UnionType);
                         $doc = $classStmt->getDocComment();
                         if ($doc !== null) {
                             $propType = $this->docTypeParser->parseType($doc->getText());
@@ -146,7 +146,7 @@ class SemanticAnalysisPass implements PassInterface
                         }
                     } elseif ($classStmt instanceof \PhpParser\Node\Stmt\ClassMethod) {
                         $methodName = $classStmt->name->toString();
-                        assert($classStmt->returnType === null || $classStmt->returnType instanceof \PhpParser\Node\Identifier || $classStmt->returnType instanceof \PhpParser\Node\NullableType || $classStmt->returnType instanceof \PhpParser\Node\Name);
+                        assert($classStmt->returnType === null || $classStmt->returnType instanceof \PhpParser\Node\Identifier || $classStmt->returnType instanceof \PhpParser\Node\NullableType || $classStmt->returnType instanceof \PhpParser\Node\Name || $classStmt->returnType instanceof \PhpParser\Node\UnionType);
                         $returnType = $classStmt->returnType !== null
                             ? $this->typeFromNode($classStmt->returnType)
                             : PicoType::fromString('void');
@@ -198,7 +198,7 @@ class SemanticAnalysisPass implements PassInterface
     {
         foreach ($stmts as $stmt) {
             if ($stmt instanceof \PhpParser\Node\Stmt\Function_) {
-                assert($stmt->returnType instanceof \PhpParser\Node\Identifier || $stmt->returnType instanceof \PhpParser\Node\NullableType || $stmt->returnType instanceof \PhpParser\Node\Name);
+                assert($stmt->returnType instanceof \PhpParser\Node\Identifier || $stmt->returnType instanceof \PhpParser\Node\NullableType || $stmt->returnType instanceof \PhpParser\Node\Name || $stmt->returnType instanceof \PhpParser\Node\UnionType);
                 $existing = $this->symbolTable->lookupCurrentScope($stmt->name->name);
                 if ($existing === null) {
                     $sym = $this->symbolTable->addSymbol(
@@ -265,8 +265,11 @@ class SemanticAnalysisPass implements PassInterface
         return $this->isSubclassOf($meta->parentName, $parentName);
     }
 
-    private function typeFromNode(\PhpParser\Node\Identifier|\PhpParser\Node\NullableType|\PhpParser\Node\Name $node): PicoType
+    private function typeFromNode(\PhpParser\Node\Identifier|\PhpParser\Node\NullableType|\PhpParser\Node\Name|\PhpParser\Node\UnionType $node): PicoType
     {
+        if ($node instanceof \PhpParser\Node\UnionType) {
+            return $this->resolveUnionType($node);
+        }
         if ($node instanceof \PhpParser\Node\NullableType) {
             $innerName = $node->type instanceof \PhpParser\Node\Name ? $node->type->toString() : $node->type->name;
             return PicoType::fromString('?' . $innerName);
@@ -279,6 +282,24 @@ class SemanticAnalysisPass implements PassInterface
             return PicoType::fromString($name);
         }
         return PicoType::fromString($node->name);
+    }
+
+    private function resolveUnionType(\PhpParser\Node\UnionType $node): PicoType
+    {
+        $types = [];
+        foreach ($node->types as $type) {
+            assert($type instanceof \PhpParser\Node\Identifier || $type instanceof \PhpParser\Node\Name);
+            $types[] = $this->typeFromNode($type);
+        }
+
+        // Widen int|float to float
+        $bases = array_map(fn (PicoType $t) => $t->toBase(), $types);
+        if (in_array(BaseType::FLOAT, $bases, true) && in_array(BaseType::INT, $bases, true)) {
+            return PicoType::fromString('float');
+        }
+
+        // For other unions, use the first type as a fallback
+        return $types[0];
     }
 
     /**
@@ -298,7 +319,7 @@ class SemanticAnalysisPass implements PassInterface
 
         if ($stmt instanceof \PhpParser\Node\Stmt\Function_) {
             assert(!is_null($stmt->returnType));
-            assert($stmt->returnType instanceof \PhpParser\Node\Identifier || $stmt->returnType instanceof \PhpParser\Node\NullableType || $stmt->returnType instanceof \PhpParser\Node\Name);
+            assert($stmt->returnType instanceof \PhpParser\Node\Identifier || $stmt->returnType instanceof \PhpParser\Node\NullableType || $stmt->returnType instanceof \PhpParser\Node\Name || $stmt->returnType instanceof \PhpParser\Node\UnionType);
             $returnType = $this->typeFromNode($stmt->returnType);
             $existing = $this->symbolTable->lookupCurrentScope($stmt->name->name);
             $pData->symbol = $existing ?? $this->symbolTable->addSymbol($stmt->name->name, $returnType, func: true);
@@ -406,7 +427,7 @@ class SemanticAnalysisPass implements PassInterface
             if ($stmt->stmts === null) {
                 return;
             }
-            assert($stmt->returnType instanceof \PhpParser\Node\Identifier || $stmt->returnType instanceof \PhpParser\Node\NullableType || $stmt->returnType instanceof \PhpParser\Node\Name || $stmt->returnType === null);
+            assert($stmt->returnType instanceof \PhpParser\Node\Identifier || $stmt->returnType instanceof \PhpParser\Node\NullableType || $stmt->returnType instanceof \PhpParser\Node\Name || $stmt->returnType instanceof \PhpParser\Node\UnionType || $stmt->returnType === null);
             $returnType = $stmt->returnType !== null ? $this->typeFromNode($stmt->returnType) : PicoType::fromString('void');
             $methodSymbol = $this->symbolTable->addSymbol($methodName, $returnType, func: true);
             $pData->symbol = $methodSymbol;
@@ -736,7 +757,7 @@ class SemanticAnalysisPass implements PassInterface
             $pData = $this->getPicoData($param);
             assert($param->var instanceof \PhpParser\Node\Expr\Variable);
             assert(is_string($param->var->name));
-            assert($param->type instanceof \PhpParser\Node\Identifier || $param->type instanceof \PhpParser\Node\NullableType || $param->type instanceof \PhpParser\Node\Name);
+            assert($param->type instanceof \PhpParser\Node\Identifier || $param->type instanceof \PhpParser\Node\NullableType || $param->type instanceof \PhpParser\Node\Name || $param->type instanceof \PhpParser\Node\UnionType);
             $paramType = $this->typeFromNode($param->type);
             $pData->symbol = $this->symbolTable->addSymbol($param->var->name, $paramType);
             $paramTypes[] = $paramType;

--- a/tests/Feature/UnionTypeTest.php
+++ b/tests/Feature/UnionTypeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles int|float parameter types', function () {
+    $file = 'tests/programs/union_types/int_float_param.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles int|float return types', function () {
+    $file = 'tests/programs/union_types/int_float_return.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles int|float property types', function () {
+    $file = 'tests/programs/union_types/int_float_property.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/union_types/int_float_param.php
+++ b/tests/programs/union_types/int_float_param.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+function addNumbers(int|float $a, int|float $b): float
+{
+    return (float) $a + (float) $b;
+}
+
+$r1 = addNumbers(10, 20);
+echo $r1;
+echo "\n";
+$r2 = addNumbers(1.5, 2.5);
+echo $r2;
+echo "\n";

--- a/tests/programs/union_types/int_float_property.php
+++ b/tests/programs/union_types/int_float_property.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+class NumberBox
+{
+    private int|float $value;
+
+    public function __construct(int|float $value)
+    {
+        $this->value = $value;
+    }
+
+    public function getAsFloat(): float
+    {
+        return (float) $this->value;
+    }
+}
+
+$a = new NumberBox(42);
+$b = new NumberBox(3.14);
+
+$v1 = $a->getAsFloat();
+echo $v1;
+echo "\n";
+$v2 = $b->getAsFloat();
+echo $v2;
+echo "\n";

--- a/tests/programs/union_types/int_float_return.php
+++ b/tests/programs/union_types/int_float_return.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+function getAsFloat(int|float $x): float
+{
+    return (float) $x;
+}
+
+$a = getAsFloat(7);
+echo $a;
+echo "\n";
+$b = getAsFloat(1.5);
+echo $b;
+echo "\n";


### PR DESCRIPTION
## Summary
- Support `int|float` union type syntax on parameters, return types, and class properties
- Union types containing both `int` and `float` are widened to `float` (`double` in LLVM IR)
- Auto-coerce `int` arguments to `float` when passed to a union-typed parameter
- Accept `UnionType` AST nodes in all type assertion points (properties, params, return types)
- Other union combinations fall back to the first type (future work for #94)

## Test plan
- [x] 85 tests pass (3 new union type tests)
- [x] PHPStan clean
- [x] Pint clean
- [x] Test programs: `int_float_param.php`, `int_float_return.php`, `int_float_property.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)