### PR TITLE
feat: add basic trait support via compile-time inlining

### DIFF
--- a/app/PicoHP/ClassToFunctionVisitor.php
+++ b/app/PicoHP/ClassToFunctionVisitor.php
@@ -15,9 +15,15 @@ class ClassToFunctionVisitor extends NodeVisitorAbstract
     /** @var Node\Stmt[] */
     protected array $globalStatements = [];
 
+    protected bool $insideTrait = false;
+
     /** @return null|int|Node|Node[] */
     public function enterNode(Node $node)
     {
+        // Skip trait nodes — traits are inlined into classes during semantic analysis
+        if ($node instanceof Node\Stmt\Trait_) {
+            $this->insideTrait = true;
+        }
         // Capture the class name for use in transformations
         if ($node instanceof Node\Stmt\Class_) {
             assert($node->name !== null);
@@ -29,7 +35,13 @@ class ClassToFunctionVisitor extends NodeVisitorAbstract
     /** @return null|int|Node|Node[] */
     public function leaveNode(Node $node)
     {
-        // TODO: handle traits and interfaces
+        if ($node instanceof Node\Stmt\Trait_) {
+            $this->insideTrait = false;
+            return null;
+        }
+        if ($this->insideTrait) {
+            return null;
+        }
 
         // TODO: theoretically, we could remove the namespace declaration
         // but we need to handle the statements inside the namespace

--- a/app/PicoHP/GlobalToMainVisitor.php
+++ b/app/PicoHP/GlobalToMainVisitor.php
@@ -34,6 +34,7 @@ class GlobalToMainVisitor extends NodeVisitorAbstract
             && !$node instanceof Node\Stmt\Function_
             && !$node instanceof Node\Stmt\Class_
             && !$node instanceof Node\Stmt\Interface_
+            && !$node instanceof Node\Stmt\Trait_
         ) {
             assert($node instanceof Node\Stmt);
             if ($node instanceof Node\Stmt\Namespace_) {

--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -246,6 +246,8 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             $fields = $classMeta->toLLVMStructFields();
             if ($fields !== '') {
                 $this->module->addLine(new IRLine("%struct.{$className} = type { {$fields} }"));
+            } else {
+                $this->module->addLine(new IRLine("%struct.{$className} = type {}"));
             }
             // Emit static properties as globals
             foreach ($classMeta->staticProperties as $propName => $propType) {
@@ -394,6 +396,8 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
 
             $this->builder->setInsertPoint($endBB);
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Interface_) {
+        } elseif ($stmt instanceof \PhpParser\Node\Stmt\Trait_) {
+            // Traits are inlined into classes at semantic analysis time; nothing to emit
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Enum_) {
             assert($stmt->name instanceof \PhpParser\Node\Identifier);
             $enumName = $stmt->name->toString();

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -24,6 +24,9 @@ class SemanticAnalysisPass implements PassInterface
     /** @var array<string, EnumMetadata> */
     protected array $enumRegistry = [];
 
+    /** @var array<string, array{properties: array<\PhpParser\Node\Stmt\Property>, methods: array<\PhpParser\Node\Stmt\ClassMethod>}> */
+    protected array $traitRegistry = [];
+
     /**
      * @param array<\PhpParser\Node> $ast
      */
@@ -101,6 +104,15 @@ class SemanticAnalysisPass implements PassInterface
      */
     protected function registerClasses(array $stmts): void
     {
+        // Pre-pass: register all traits before processing classes
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof \PhpParser\Node\Stmt\Namespace_) {
+                $this->registerTraits($stmt->stmts);
+            } elseif ($stmt instanceof \PhpParser\Node\Stmt\Trait_) {
+                $this->registerTrait($stmt);
+            }
+        }
+
         foreach ($stmts as $stmt) {
             if ($stmt instanceof \PhpParser\Node\Stmt\Namespace_) {
                 $this->registerClasses($stmt->stmts);
@@ -125,6 +137,26 @@ class SemanticAnalysisPass implements PassInterface
                 if ($this->isExceptionClass($className)) {
                     $this->typeIdMap[$className] = $this->nextTypeId++;
                 }
+                // Inline trait members into class AST
+                $inlinedStmts = [];
+                foreach ($stmt->stmts as $classStmt) {
+                    if ($classStmt instanceof \PhpParser\Node\Stmt\TraitUse) {
+                        foreach ($classStmt->traits as $traitName) {
+                            $name = $traitName->toString();
+                            assert(isset($this->traitRegistry[$name]), "trait {$name} not found");
+                            $trait = $this->traitRegistry[$name];
+                            foreach ($trait['properties'] as $prop) {
+                                $inlinedStmts[] = clone $prop;
+                            }
+                            foreach ($trait['methods'] as $method) {
+                                $inlinedStmts[] = clone $method;
+                            }
+                        }
+                    } else {
+                        $inlinedStmts[] = $classStmt;
+                    }
+                }
+                $stmt->stmts = $inlinedStmts;
                 foreach ($stmt->stmts as $classStmt) {
                     if ($classStmt instanceof \PhpParser\Node\Stmt\Property) {
                         assert($classStmt->type instanceof \PhpParser\Node\Identifier || $classStmt->type instanceof \PhpParser\Node\NullableType || $classStmt->type instanceof \PhpParser\Node\Name);
@@ -186,6 +218,36 @@ class SemanticAnalysisPass implements PassInterface
                 }
             }
         }
+    }
+
+    /**
+     * Pre-pass: register all traits from a list of statements.
+     *
+     * @param array<\PhpParser\Node\Stmt> $stmts
+     */
+    protected function registerTraits(array $stmts): void
+    {
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof \PhpParser\Node\Stmt\Trait_) {
+                $this->registerTrait($stmt);
+            }
+        }
+    }
+
+    protected function registerTrait(\PhpParser\Node\Stmt\Trait_ $stmt): void
+    {
+        assert($stmt->name instanceof \PhpParser\Node\Identifier);
+        $traitName = $stmt->name->toString();
+        $properties = [];
+        $methods = [];
+        foreach ($stmt->stmts as $traitStmt) {
+            if ($traitStmt instanceof \PhpParser\Node\Stmt\Property) {
+                $properties[] = $traitStmt;
+            } elseif ($traitStmt instanceof \PhpParser\Node\Stmt\ClassMethod) {
+                $methods[] = $traitStmt;
+            }
+        }
+        $this->traitRegistry[$traitName] = ['properties' => $properties, 'methods' => $methods];
     }
 
     /**
@@ -453,6 +515,8 @@ class SemanticAnalysisPass implements PassInterface
             if ($stmt->finally !== null) {
                 $this->resolveStmts($stmt->finally->stmts);
             }
+        } elseif ($stmt instanceof \PhpParser\Node\Stmt\Trait_) {
+            // Traits are inlined into classes during registration; skip
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Namespace_) {
             $this->resolveStmts($stmt->stmts);
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\InlineHTML) {

--- a/tests/Feature/TraitTest.php
+++ b/tests/Feature/TraitTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles basic trait usage', function () {
+    $file = 'tests/programs/classes/trait_basic.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles trait with properties', function () {
+    $file = 'tests/programs/classes/trait_with_property.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles multiple traits', function () {
+    $file = 'tests/programs/classes/trait_multiple.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/classes/trait_basic.php
+++ b/tests/programs/classes/trait_basic.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+trait Greeter
+{
+    public function greet(string $name): string
+    {
+        return "Hello, " . $name;
+    }
+}
+
+class MyClass
+{
+    use Greeter;
+}
+
+$obj = new MyClass();
+echo $obj->greet("World") . "\n";

--- a/tests/programs/classes/trait_multiple.php
+++ b/tests/programs/classes/trait_multiple.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+trait HasName
+{
+    private string $name;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+}
+
+trait HasAge
+{
+    private int $age;
+
+    public function getAge(): int
+    {
+        return $this->age;
+    }
+
+    public function setAge(int $age): void
+    {
+        $this->age = $age;
+    }
+}
+
+class Person
+{
+    use HasName;
+    use HasAge;
+
+    public function __construct(string $name, int $age)
+    {
+        $this->name = $name;
+        $this->age = $age;
+    }
+}
+
+$p = new Person("Alice", 30);
+echo $p->getName() . "\n";
+echo $p->getAge();
+echo "\n";

--- a/tests/programs/classes/trait_with_property.php
+++ b/tests/programs/classes/trait_with_property.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+trait Counter
+{
+    private int $count;
+
+    public function increment(): void
+    {
+        $this->count = $this->count + 1;
+    }
+
+    public function getCount(): int
+    {
+        return $this->count;
+    }
+}
+
+class MyCounter
+{
+    use Counter;
+
+    public function __construct()
+    {
+        $this->count = 0;
+    }
+}
+
+$c = new MyCounter();
+$c->increment();
+$c->increment();
+$c->increment();
+echo $c->getCount();
+echo "\n";


### PR DESCRIPTION
## Summary
- Implement PHP traits by inlining trait methods and properties into classes during semantic analysis
- Support basic trait usage, traits with properties, and multiple traits per class
- Trait_ nodes are skipped in ClassToFunctionVisitor, GlobalToMainVisitor, and IRGenerationPass
- TraitUse statements are replaced with cloned trait members before class registration

## Test plan
- [x] 85 tests pass (3 new trait tests)
- [x] PHPStan clean
- [x] Pint clean
- [x] Test programs: `trait_basic.php`, `trait_with_property.php`, `trait_multiple.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)