### PR TITLE
feat: add type cast expressions (int, float, bool, string)

### DIFF
--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -602,6 +602,30 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                 default:
                     throw new \Exception("casting to float from unknown type");
             }
+        } elseif ($expr instanceof \PhpParser\Node\Expr\Cast\Bool_) {
+            $val = $this->buildExpr($expr->expr);
+
+            switch ($val->getType()) {
+                case BaseType::INT:
+                    return $this->builder->createInstruction('icmp ne', [$val, new Constant(0, BaseType::INT)], resultType: BaseType::BOOL);
+                case BaseType::FLOAT:
+                    return $this->builder->createInstruction('fcmp one', [$val, new Constant(0.0, BaseType::FLOAT)], resultType: BaseType::BOOL);
+                case BaseType::BOOL:
+                    return $val;
+                default:
+                    throw new \Exception("casting to bool from unknown type");
+            }
+        } elseif ($expr instanceof \PhpParser\Node\Expr\Cast\String_) {
+            $val = $this->buildExpr($expr->expr);
+
+            switch ($val->getType()) {
+                case BaseType::INT:
+                    return $this->builder->createCall('pico_int_to_string', [$val], BaseType::STRING);
+                case BaseType::STRING:
+                    return $val;
+                default:
+                    throw new \Exception("casting to string from unsupported type");
+            }
         } elseif ($expr instanceof \PhpParser\Node\Expr\FuncCall) {
             assert($expr->name instanceof \PhpParser\Node\Name);
             $funcName = $expr->name->toLowerString();

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -661,6 +661,12 @@ class SemanticAnalysisPass implements PassInterface
         } elseif ($expr instanceof \PhpParser\Node\Expr\Cast\Double) {
             $this->resolveExpr($expr->expr);
             return PicoType::fromString('float');
+        } elseif ($expr instanceof \PhpParser\Node\Expr\Cast\Bool_) {
+            $this->resolveExpr($expr->expr);
+            return PicoType::fromString('bool');
+        } elseif ($expr instanceof \PhpParser\Node\Expr\Cast\String_) {
+            $this->resolveExpr($expr->expr);
+            return PicoType::fromString('string');
         } elseif ($expr instanceof \PhpParser\Node\Expr\ClassConstFetch) {
             assert($expr->class instanceof \PhpParser\Node\Name);
             assert($expr->name instanceof \PhpParser\Node\Identifier);

--- a/tests/Feature/CastTest.php
+++ b/tests/Feature/CastTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles type cast expressions', function () {
+    $file = 'tests/programs/operators/cast.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/operators/cast.php
+++ b/tests/programs/operators/cast.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+function testCasts(): void
+{
+    $i = 42;
+    $f = 3.14;
+
+    $fi = (float) $i;
+    echo $fi;
+    echo "\n";
+
+    $if = (int) $f;
+    echo $if;
+    echo "\n";
+
+    $b = (bool) $i;
+    if ($b) { /** @phpstan-ignore if.alwaysTrue */
+        echo "true\n";
+    }
+
+    $b0 = (bool) 0;
+    if ($b0) { /** @phpstan-ignore if.alwaysFalse */
+        echo "should not print\n";
+    } else {
+        echo "false\n";
+    }
+}
+
+testCasts();


### PR DESCRIPTION
## Summary
- Support `(int)`, `(float)`, `(bool)`, and `(string)` cast expressions
- `(bool)` uses `icmp ne`/`fcmp one` against zero
- `(string)` on int calls `pico_int_to_string`; float-to-string deferred (no runtime function yet)
- `(int)` and `(float)` casts already existed; adds `(bool)` and `(string)`

## Test plan
- [x] All 92 tests pass (1 new)
- [x] PHPStan clean, Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)