### PR TITLE
feat: support untyped properties with PHPDoc type annotations

### DIFF
--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -159,12 +159,19 @@ class SemanticAnalysisPass implements PassInterface
                 $stmt->stmts = $inlinedStmts;
                 foreach ($stmt->stmts as $classStmt) {
                     if ($classStmt instanceof \PhpParser\Node\Stmt\Property) {
-                        assert($classStmt->type instanceof \PhpParser\Node\Identifier || $classStmt->type instanceof \PhpParser\Node\NullableType || $classStmt->type instanceof \PhpParser\Node\Name || $classStmt->type instanceof \PhpParser\Node\UnionType);
-                        $doc = $classStmt->getDocComment();
-                        if ($doc !== null) {
+                        if ($classStmt->type === null) {
+                            // No native type hint — require PHPDoc
+                            $doc = $classStmt->getDocComment();
+                            assert($doc !== null, 'untyped property requires PHPDoc type annotation');
                             $propType = $this->docTypeParser->parseType($doc->getText());
                         } else {
-                            $propType = $this->typeFromNode($classStmt->type);
+                            assert($classStmt->type instanceof \PhpParser\Node\Identifier || $classStmt->type instanceof \PhpParser\Node\NullableType || $classStmt->type instanceof \PhpParser\Node\Name || $classStmt->type instanceof \PhpParser\Node\UnionType);
+                            $doc = $classStmt->getDocComment();
+                            if ($doc !== null) {
+                                $propType = $this->docTypeParser->parseType($doc->getText());
+                            } else {
+                                $propType = $this->typeFromNode($classStmt->type);
+                            }
                         }
                         if ($classStmt->isStatic()) {
                             foreach ($classStmt->props as $prop) {

--- a/app/PicoHP/SymbolTable/DocTypeParser.php
+++ b/app/PicoHP/SymbolTable/DocTypeParser.php
@@ -39,10 +39,17 @@ class DocTypeParser
             $typeNode = $tag->type;
             if ($typeNode instanceof GenericTypeNode
                 && $typeNode->type->name === 'array'
-                && count($typeNode->genericTypes) === 2
-                && $typeNode->genericTypes[1] instanceof IdentifierTypeNode
             ) {
-                return PicoType::array(PicoType::fromString($typeNode->genericTypes[1]->name));
+                if (count($typeNode->genericTypes) === 2
+                    && $typeNode->genericTypes[1] instanceof IdentifierTypeNode
+                ) {
+                    return PicoType::array(PicoType::fromString($typeNode->genericTypes[1]->name));
+                }
+                if (count($typeNode->genericTypes) === 1
+                    && $typeNode->genericTypes[0] instanceof IdentifierTypeNode
+                ) {
+                    return PicoType::array(PicoType::fromString($typeNode->genericTypes[0]->name));
+                }
             }
             return PicoType::fromString((string)$typeNode);
         }

--- a/tests/Feature/UntypedPropertyTest.php
+++ b/tests/Feature/UntypedPropertyTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles untyped property with PHPDoc type', function () {
+    $file = 'tests/programs/classes/untyped_property.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles untyped array property with PHPDoc type', function () {
+    $file = 'tests/programs/classes/untyped_array_property.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/classes/untyped_array_property.php
+++ b/tests/programs/classes/untyped_array_property.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+class Collection
+{
+    /** @var array<int> */
+    private $items;
+
+    public function __construct()
+    {
+        $this->items = [];
+    }
+
+    public function add(int $item): void
+    {
+        $this->items[] = $item;
+    }
+
+    public function count(): int
+    {
+        return count($this->items);
+    }
+}
+
+$c = new Collection();
+$c->add(1);
+$c->add(2);
+$c->add(3);
+echo $c->count();
+echo "\n";

--- a/tests/programs/classes/untyped_property.php
+++ b/tests/programs/classes/untyped_property.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+class Container
+{
+    /** @var int */
+    private $value;
+
+    public function __construct(int $value)
+    {
+        $this->value = $value;
+    }
+
+    public function getValue(): int
+    {
+        return $this->value;
+    }
+}
+
+$c = new Container(42);
+echo $c->getValue();
+echo "\n";


### PR DESCRIPTION
## Summary
- Allow class/trait properties without native type hints, falling back to PHPDoc `@var` annotations
- Fix DocTypeParser to handle single-generic arrays like `array<int>` (previously only `array<key, value>`)
- Unblocks self-compilation of files using NodeTrait (`private $children = []`)

## Test plan
- [x] All 93 tests pass (2 new)
- [x] PHPStan clean, Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)