### PR TITLE
chore: add Illuminate\Support stub files for self-compilation

### DIFF
--- a/self-host-check.php
+++ b/self-host-check.php
@@ -114,6 +114,8 @@ function stubbedSingleFileCheck(string $picoHP, string $tmpDir, bool $verbose): 
     $stubs = [
         __DIR__ . '/tests/programs/self_compile/basetype_stub.php',
         __DIR__ . '/tests/programs/self_compile/runtime_exception_stub.php',
+        __DIR__ . '/tests/programs/self_compile/illuminate_str_stub.php',
+        __DIR__ . '/tests/programs/self_compile/illuminate_arr_stub.php',
         __DIR__ . '/app/PicoHP/Tree/NodeInterface.php',
         __DIR__ . '/app/PicoHP/PassInterface.php',
         __DIR__ . '/app/PicoHP/LLVM/ValueAbstract.php',
@@ -229,10 +231,15 @@ function multiFileCheck(string $picoHP, string $tmpDir, bool $verbose): void
             __DIR__ . '/app/PicoHP/LLVM/Value/Label.php',
         ],
         'LLVM IR infrastructure' => [
+            __DIR__ . '/tests/programs/self_compile/runtime_exception_stub.php',
+            __DIR__ . '/tests/programs/self_compile/illuminate_str_stub.php',
+            __DIR__ . '/app/PicoHP/Tree/NodeInterface.php',
+            __DIR__ . '/app/PicoHP/Tree/NodeTrait.php',
             __DIR__ . '/app/PicoHP/LLVM/IRLine.php',
             __DIR__ . '/app/PicoHP/LLVM/BasicBlock.php',
         ],
         'Symbol table' => [
+            __DIR__ . '/tests/programs/self_compile/illuminate_arr_stub.php',
             __DIR__ . '/app/PicoHP/SymbolTable/Symbol.php',
             __DIR__ . '/app/PicoHP/SymbolTable/Scope.php',
             __DIR__ . '/app/PicoHP/SymbolTable.php',

--- a/tests/programs/self_compile/illuminate_arr_stub.php
+++ b/tests/programs/self_compile/illuminate_arr_stub.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+class Arr
+{
+    /**
+     * @param array<string, mixed> $array
+     */
+    public static function exists(array $array, string $key): bool
+    {
+        // TODO: needs array_key_exists or isset support in picoHP
+        // For now this provides the correct API signature for self-host testing
+        return false;
+    }
+
+    /**
+     * @param array<mixed> $array
+     * @return mixed
+     */
+    public static function last(array $array)
+    {
+        $count = count($array);
+        if ($count === 0) {
+            return null;
+        }
+        return $array[$count - 1];
+    }
+}

--- a/tests/programs/self_compile/illuminate_str_stub.php
+++ b/tests/programs/self_compile/illuminate_str_stub.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+class Str
+{
+    /**
+     * @param array<string> $needles
+     */
+    public static function startsWith(string $haystack, array $needles): bool
+    {
+        /** @var string $needle */
+        foreach ($needles as $needle) {
+            if (str_starts_with($haystack, $needle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- Add minimal `Str` stub with `startsWith()` using picoHP-supported `str_starts_with()`
- Add minimal `Arr` stub with `exists()` (placeholder) and `last()` using `count()` + indexing
- Add stubs to self-host-check.php stubbed single-file and multi-file groups

## Test plan
- [x] All existing tests pass
- [x] Self-host check runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)