### PR TITLE
feat: support foreach key variables

### DIFF
--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -389,6 +389,12 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             $this->builder->setInsertPoint($bodyBB);
             $elemVal = $this->builder->createArrayGet($arrayPtr, $idx, $arrayType->getElementBaseType());
             $this->builder->createStore($elemVal, $valuePtr);
+            if ($stmt->keyVar !== null) {
+                assert($stmt->keyVar instanceof \PhpParser\Node\Expr\Variable);
+                $keyVarPData = PicoHPData::getPData($stmt->keyVar);
+                $keyPtr = $keyVarPData->getValue();
+                $this->builder->createStore($idx, $keyPtr);
+            }
             $this->buildStmts($stmt->stmts);
             $idxNext = $this->builder->createInstruction('add', [$idx, new Constant(1, BaseType::INT)]);
             $this->builder->createStore($idxNext, $counterPtr);

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -460,7 +460,15 @@ class SemanticAnalysisPass implements PassInterface
                 $stmt->valueVar->name,
                 $arrayType->getElementType()
             );
-            // TODO: key var support
+            if ($stmt->keyVar !== null) {
+                assert($stmt->keyVar instanceof \PhpParser\Node\Expr\Variable);
+                assert(is_string($stmt->keyVar->name));
+                $keyVarPData = $this->getPicoData($stmt->keyVar);
+                $keyVarPData->symbol = $this->symbolTable->addSymbol(
+                    $stmt->keyVar->name,
+                    PicoType::fromString('int')
+                );
+            }
             $this->resolveStmts($stmt->stmts);
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Class_) {
             assert($stmt->name instanceof \PhpParser\Node\Identifier);

--- a/tests/Feature/ForeachTest.php
+++ b/tests/Feature/ForeachTest.php
@@ -16,6 +16,20 @@ it('handles foreach over indexed array', function () {
     expect($compiled_output)->toBe($php_output);
 });
 
+it('handles foreach with key variable', function () {
+    $file = 'tests/programs/foreach/foreach_key.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
 it('handles nested foreach loops', function () {
     $file = 'tests/programs/foreach/nested_foreach.php';
 

--- a/tests/programs/foreach/foreach_key.php
+++ b/tests/programs/foreach/foreach_key.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var array<int, string> */
+$names = ['alice', 'bob', 'charlie'];
+
+foreach ($names as $i => $name) {
+    echo $i;
+    echo ": ";
+    echo $name;
+    echo "\n";
+}


### PR DESCRIPTION
## Summary
- Add support for \`foreach (\$arr as \$key => \$value)\` key variable
- Register key variable in symbol table during semantic analysis
- Emit IR to store loop counter into key variable alloca
- Note: \$this was already supported — the actual blocker for ClassMetadata self-compilation was missing foreach key support

## Test plan
- [x] All tests pass (1 new foreach_key test)
- [x] PHPStan clean, Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)