### PR TITLE
feat: add pico_float_to_string and pico_float_to_hex runtime

### DIFF
--- a/app/PicoHP/LLVM/Builder.php
+++ b/app/PicoHP/LLVM/Builder.php
@@ -33,6 +33,8 @@ class Builder
         $this->addLine('declare i32 @pico_rt_version()');
         $this->addLine('declare i32 @pico_string_len(ptr)');
         $this->addLine('declare ptr @pico_int_to_string(i32)');
+        $this->addLine('declare ptr @pico_float_to_string(double)');
+        $this->addLine('declare ptr @pico_float_to_hex(double)');
         $this->addLine('declare i32 @pico_string_starts_with(ptr, ptr)');
         $this->addLine('declare i32 @pico_string_contains(ptr, ptr)');
         $this->addLine('declare ptr @pico_string_substr(ptr, i32, i32)');

--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -627,6 +627,8 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             switch ($val->getType()) {
                 case BaseType::INT:
                     return $this->builder->createCall('pico_int_to_string', [$val], BaseType::STRING);
+                case BaseType::FLOAT:
+                    return $this->builder->createCall('pico_float_to_string', [$val], BaseType::STRING);
                 case BaseType::STRING:
                     return $val;
                 default:
@@ -646,6 +648,9 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                 assert(count($expr->args) === 1);
                 assert($expr->args[0] instanceof \PhpParser\Node\Arg);
                 $val = $this->buildExpr($expr->args[0]->value);
+                if ($val->getType() === BaseType::FLOAT) {
+                    return $this->builder->createCall('pico_float_to_string', [$val], BaseType::STRING);
+                }
                 return $this->builder->createCall('pico_int_to_string', [$val], BaseType::STRING);
             }
             if ($funcName === 'strlen') {

--- a/examples/test-proj/vendor/composer/installed.php
+++ b/examples/test-proj/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'brandin/test-proj',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'a355ccfd31990340d91b3e51e9599d0948144092',
+        'reference' => '45c88b518ec5ebe03dcaf404df218fedef3c75a3',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'brandin/test-proj' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'a355ccfd31990340d91b3e51e9599d0948144092',
+            'reference' => '45c88b518ec5ebe03dcaf404df218fedef3c75a3',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_char, CStr};
+use std::ffi::{c_char, c_int, CStr, CString};
 
 /// Returns the runtime version as an integer.
 #[no_mangle]
@@ -30,7 +30,38 @@ pub extern "C" fn pico_string_concat(a: *const c_char, b: *const c_char) -> *mut
 #[no_mangle]
 pub extern "C" fn pico_int_to_string(val: i32) -> *mut c_char {
     let s = val.to_string();
-    let c_str = std::ffi::CString::new(s).unwrap();
+    let c_str = CString::new(s).unwrap();
+    c_str.into_raw()
+}
+
+extern "C" {
+    fn snprintf(s: *mut c_char, n: usize, format: *const c_char, ...) -> c_int;
+}
+
+/// Convert f64 to string matching PHP's `(string)` cast (%.14G format).
+#[no_mangle]
+pub extern "C" fn pico_float_to_string(val: f64) -> *mut c_char {
+    let mut buf = [0u8; 64];
+    let fmt = b"%.14G\0";
+    let len = unsafe {
+        snprintf(
+            buf.as_mut_ptr() as *mut c_char,
+            buf.len(),
+            fmt.as_ptr() as *const c_char,
+            val,
+        )
+    };
+    let s = &buf[..len as usize];
+    let c_str = CString::new(s).unwrap();
+    c_str.into_raw()
+}
+
+/// Convert f64 to its IEEE 754 hex representation (e.g. "0x400921FB54442D18").
+#[no_mangle]
+pub extern "C" fn pico_float_to_hex(val: f64) -> *mut c_char {
+    let bits = val.to_bits();
+    let s = format!("0x{:016X}", bits);
+    let c_str = CString::new(s).unwrap();
     c_str.into_raw()
 }
 
@@ -596,6 +627,33 @@ mod tests {
         pico_array_push_float(arr, 1.0);
         pico_array_set_float(arr, 0, 9.9);
         assert!((pico_array_get_float(arr, 0) - 9.9).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_float_to_string() {
+        let check = |val: f64, expected: &str| {
+            let ptr = pico_float_to_string(val);
+            let result = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap();
+            assert_eq!(result, expected, "pico_float_to_string({}) = {:?}, expected {:?}", val, result, expected);
+        };
+        check(3.14, "3.14");
+        check(0.0, "0");
+        check(100.0, "100");
+        check(-2.5, "-2.5");
+        check(1e10, "10000000000");
+        check(0.1, "0.1");
+        check(0.5, "0.5");
+    }
+
+    #[test]
+    fn test_float_to_hex() {
+        let ptr = pico_float_to_hex(3.14);
+        let result = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap();
+        assert_eq!(result, "0x40091EB851EB851F");
+
+        let ptr2 = pico_float_to_hex(0.0);
+        let result2 = unsafe { CStr::from_ptr(ptr2) }.to_str().unwrap();
+        assert_eq!(result2, "0x0000000000000000");
     }
 
     #[test]

--- a/tests/Feature/CastTest.php
+++ b/tests/Feature/CastTest.php
@@ -15,3 +15,17 @@ it('handles type cast expressions', function () {
 
     expect($compiled_output)->toBe($php_output);
 });
+
+it('handles (string) cast on floats', function () {
+    $file = 'tests/programs/operators/string_cast_float.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/operators/string_cast_float.php
+++ b/tests/programs/operators/string_cast_float.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+function formatFloat(float $f): string
+{
+    return (string) $f;
+}
+
+echo formatFloat(3.14);
+echo "\n";
+echo formatFloat(0.0);
+echo "\n";
+echo formatFloat(100.0);
+echo "\n";
+echo formatFloat(0.5);
+echo "\n";


### PR DESCRIPTION
## Summary
- Add `pico_float_to_string(f64)` Rust runtime function matching PHP's `%.14G` format
- Add `pico_float_to_hex(f64)` for LLVM IR hex float literals
- Enable `(string)` cast on float types in IRGenerationPass
- Fix `strval()` to dispatch by type (int → `pico_int_to_string`, float → `pico_float_to_string`)

## Test plan
- [x] 96 tests pass (1 new float string cast test)
- [x] 21 Rust runtime tests pass
- [x] PHPStan clean, Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)