### PR TITLE
feat: add list/array destructuring and foreach on mixed

### DIFF
--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -34,6 +34,21 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
 
     protected int $vdispatchCount = 0;
 
+    protected function isDestructuringAssign(\PhpParser\Node\Expr\Assign $expr): bool
+    {
+        if (!($expr->var instanceof \PhpParser\Node\Expr\Array_)) {
+            return false;
+        }
+        // If the LHS array items are variables, it's destructuring
+        foreach ($expr->var->items as $item) {
+            /** @phpstan-ignore-next-line — items can be null for skipped positions */
+            if ($item !== null && $item->value instanceof \PhpParser\Node\Expr\Variable) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /** @var array<string> stack of break target block names */
     protected array $breakTargets = [];
 
@@ -512,6 +527,25 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
         $pData = PicoHPData::getPData($expr);
 
         if ($expr instanceof \PhpParser\Node\Expr\Assign) {
+            // List/array destructuring: [$a, $b] = $arr
+            if ($expr->var instanceof \PhpParser\Node\Expr\List_
+                || ($expr->var instanceof \PhpParser\Node\Expr\Array_ && $this->isDestructuringAssign($expr))) {
+                $arrVal = $this->buildExpr($expr->expr);
+                $arrType = $this->getExprResolvedType($expr->expr);
+                $items = $expr->var instanceof \PhpParser\Node\Expr\List_
+                    ? $expr->var->items
+                    : $expr->var->items;
+                foreach ($items as $i => $item) {
+                    /** @phpstan-ignore-next-line — items can be null for skipped positions */
+                    if ($item !== null && $item->value !== null) {
+                        $lval = $this->buildExpr($item->value);
+                        $elemType = $arrType->isArray() ? $arrType->getElementBaseType() : BaseType::PTR;
+                        $elemVal = $this->builder->createArrayGet($arrVal, new Constant($i, BaseType::INT), $elemType);
+                        $this->builder->createStore($elemVal, $lval);
+                    }
+                }
+                return $arrVal;
+            }
             // Array literal: $arr = [1, 2, 3]
             if ($expr->expr instanceof \PhpParser\Node\Expr\Array_) {
                 $lval = $this->buildExpr($expr->var);

--- a/app/PicoHP/Pass/SemanticAnalysisPass.php
+++ b/app/PicoHP/Pass/SemanticAnalysisPass.php
@@ -552,13 +552,14 @@ class SemanticAnalysisPass implements PassInterface
             // Class constants handled during class registration
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Foreach_) {
             $arrayType = $this->resolveExpr($stmt->expr);
-            assert($arrayType->isArray(), "foreach expression must be an array, got {$arrayType->toString()}");
+            assert($arrayType->isArray() || $arrayType->isMixed(), "foreach expression must be an array, got {$arrayType->toString()}");
             assert($stmt->valueVar instanceof \PhpParser\Node\Expr\Variable);
             assert(is_string($stmt->valueVar->name));
             $valueVarPData = $this->getPicoData($stmt->valueVar);
+            $elementType = $arrayType->isMixed() ? PicoType::fromString('mixed') : $arrayType->getElementType();
             $valueVarPData->symbol = $this->symbolTable->addSymbol(
                 $stmt->valueVar->name,
-                $arrayType->getElementType()
+                $elementType
             );
             if ($stmt->keyVar !== null) {
                 assert($stmt->keyVar instanceof \PhpParser\Node\Expr\Variable);
@@ -663,6 +664,22 @@ class SemanticAnalysisPass implements PassInterface
 
         if ($expr instanceof \PhpParser\Node\Expr\Assign) {
             $rtype = $this->resolveExpr($expr->expr);
+            // List/array destructuring: [$a, $b] = $arr
+            if ($expr->var instanceof \PhpParser\Node\Expr\List_
+                || ($expr->var instanceof \PhpParser\Node\Expr\Array_)) {
+                $items = $expr->var instanceof \PhpParser\Node\Expr\List_
+                    ? $expr->var->items
+                    : $expr->var->items;
+                $elementType = $rtype->isArray() ? $rtype->getElementType()
+                    : ($rtype->isMixed() ? PicoType::fromString('mixed') : $rtype);
+                foreach ($items as $item) {
+                    /** @phpstan-ignore-next-line — items can be null for skipped positions */
+                    if ($item !== null && $item->value !== null) {
+                        $this->resolveExpr($item->value, $item->value->getDocComment(), lVal: true, rType: $elementType);
+                    }
+                }
+                return $rtype;
+            }
             $ltype = $this->resolveExpr($expr->var, $doc, lVal: true, rType: $rtype);
             $line = $this->getLine($expr);
             $compatible = $ltype->isEqualTo($rtype)

--- a/tests/Feature/ListDestructureTest.php
+++ b/tests/Feature/ListDestructureTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles list destructuring with integers', function () {
+    $file = 'tests/programs/arrays/list_destructure.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles list destructuring with strings', function () {
+    $file = 'tests/programs/arrays/list_destructure_string.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->artisan("build --debug {$file}")->assertExitCode(0);
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/arrays/list_destructure.php
+++ b/tests/programs/arrays/list_destructure.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var array<int, int> $nums */
+$nums = [10, 20, 30];
+
+/** @var int $a */
+/** @var int $b */
+/** @var int $c */
+[$a, $b, $c] = $nums;
+
+echo $a;
+echo "\n";
+echo $b;
+echo "\n";
+echo $c;
+echo "\n";

--- a/tests/programs/arrays/list_destructure_string.php
+++ b/tests/programs/arrays/list_destructure_string.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var array<int, string> $parts */
+$parts = ["hello", "world"];
+
+/** @var string $first */
+/** @var string $second */
+[$first, $second] = $parts;
+
+echo $first . "\n";
+echo $second . "\n";


### PR DESCRIPTION
## Summary
- Support \`[\$a, \$b, \$c] = \$arr\` destructuring (List_ and Array_ on LHS of assign)
- Foreach on mixed-typed expressions (element type resolves to mixed)
- isDestructuringAssign helper to distinguish destructuring from array literal

## Php8 parser progress
Gets past list() destructuring and foreach on mixed. Next blocker: static method calls on Node classes (Node_Scalar_String__parseEscapeSequences).

Closes #142

## Test plan
- [x] 138 tests pass (2 new: list_destructure, list_destructure_string)
- [x] PHPStan clean, Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)