### PR TITLE
feat: add $argc/$argv support and fix ternary alloca (#130)

### DIFF
--- a/app/PicoHP/GlobalToMainVisitor.php
+++ b/app/PicoHP/GlobalToMainVisitor.php
@@ -95,14 +95,26 @@ class GlobalToMainVisitor extends NodeVisitorAbstract
             new Node\Scalar\LNumber(0)
         );
 
-        // Create a `main` function with the collected statements
+        // Create a `main` function with argc/argv parameters
+        /** @param list<string> $argv */
         $mainFunction = new Node\Stmt\Function_(
             'main',
             [
+                'params' => [
+                    new Node\Param(
+                        new Node\Expr\Variable('argc'),
+                        type: new Node\Identifier('int'),
+                    ),
+                    new Node\Param(
+                        new Node\Expr\Variable('argv'),
+                        type: new Node\Identifier('array'),
+                    ),
+                ],
                 'stmts' => $this->globalStatements,
                 'returnType' => new Node\Identifier('int'),
             ]
         );
+        $mainFunction->setDocComment(new \PhpParser\Comment\Doc('/** @param list<string> $argv */'));
 
         return array_merge(
             $declareNodes,

--- a/app/PicoHP/LLVM/BasicBlock.php
+++ b/app/PicoHP/LLVM/BasicBlock.php
@@ -45,6 +45,14 @@ class BasicBlock implements NodeInterface
     }
 
     /**
+     * Insert a line right after the block label (index 0), before any other instructions.
+     */
+    public function insertAtStart(IRLine $line): void
+    {
+        array_splice($this->lines, 1, 0, [$line]);
+    }
+
+    /**
      * @return array<IRLine>
      */
     public function getLines(): array

--- a/app/PicoHP/LLVM/Builder.php
+++ b/app/PicoHP/LLVM/Builder.php
@@ -61,6 +61,9 @@ class Builder
         $this->addLine('%result.i1 = type { i1, i1, ptr }');
         $this->addLine('%result.ptr = type { i1, ptr, ptr }');
         $this->addLine();
+        $this->addLine('; argv');
+        $this->addLine('declare ptr @pico_argv_to_array(i32, ptr)');
+        $this->addLine();
         $this->addLine('; array runtime');
         $this->addLine('declare ptr @pico_array_new()');
         $this->addLine('declare i32 @pico_array_len(ptr)');
@@ -156,6 +159,18 @@ class Builder
     {
         $resultVal = new AllocaInst($name, $type);
         $this->addLine("{$resultVal->render()} = alloca {$type->toLLVM()}", 1);
+        return $resultVal;
+    }
+
+    /**
+     * Emit an alloca in the entry block of the given function, ensuring it dominates all uses.
+     */
+    public function createEntryAlloca(Function_ $function, string $name, BaseType $type): ValueAbstract
+    {
+        $resultVal = new AllocaInst($name, $type);
+        $blocks = $function->getBasicBlocks();
+        \App\PicoHP\CompilerInvariant::check(count($blocks) > 0);
+        $blocks[0]->insertAtStart(new IRLine("    {$resultVal->render()} = alloca {$type->toLLVM()}"));
         return $resultVal;
     }
 

--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -190,6 +190,9 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                         $symbol->value = $this->buildSymbolAlloca($symbol);
                     }
                     $this->buildParams($stmt->params);
+                    if ($stmt->name->toString() === 'main') {
+                        $this->emitMainArgvConversion($stmt->params);
+                    }
                     $this->buildStmts($stmt->stmts);
                 } catch (\Throwable) {
                     $this->sealAllBlocks();
@@ -1660,7 +1663,7 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
 
             $this->builder->setInsertPoint($thenBB);
             $thenVal = $this->buildExpr($expr->if ?? $expr->cond);
-            $resultPtr = $this->builder->createAlloca("ternary_result{$count}", $thenVal->getType());
+            $resultPtr = $this->builder->createEntryAlloca($this->currentFunction, "ternary_result{$count}", $thenVal->getType());
             $this->builder->createStore($thenVal, $resultPtr);
             $this->builder->createBranch([new Label($endBB->getName())]);
 
@@ -2752,6 +2755,36 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
             $type = $pData->getSymbol()->type;
             $this->builder->createStore(new Param($count++, $type->toBase()), $pData->getValue());
         }
+    }
+
+    /**
+     * Convert raw C main(argc, argv) into a PicoArray for $argv.
+     * After buildParams stores the raw ptr, replace $argv with the converted array.
+     *
+     * @param array<\PhpParser\Node\Param> $params
+     */
+    protected function emitMainArgvConversion(array $params): void
+    {
+        // Find $argc and $argv params
+        $argcVal = null;
+        $argvPtr = null;
+        foreach ($params as $param) {
+            \App\PicoHP\CompilerInvariant::check($param->var instanceof \PhpParser\Node\Expr\Variable);
+            if ($param->var->name === 'argc') {
+                $argcVal = $this->builder->createLoad(PicoHPData::getPData($param)->getValue());
+            } elseif ($param->var->name === 'argv') {
+                $argvPtr = PicoHPData::getPData($param)->getValue();
+            }
+        }
+        if ($argcVal === null || $argvPtr === null) {
+            return;
+        }
+        // Load raw char** argv, convert to PicoArray
+        $rawArgv = $this->builder->createLoad($argvPtr);
+        $picoArray = new \App\PicoHP\LLVM\Value\Instruction('argv_arr', BaseType::PTR);
+        $this->builder->addLine("{$picoArray->render()} = call ptr @pico_argv_to_array(i32 {$argcVal->render()}, ptr {$rawArgv->render()})", 1);
+        // Store PicoArray back into $argv alloca
+        $this->builder->createStore($picoArray, $argvPtr);
     }
 
     /**

--- a/picoHP
+++ b/picoHP
@@ -7,7 +7,6 @@ $baseDir = __DIR__;
 
 require $baseDir . '/vendor/autoload.php';
 
-/** @var list<string> $cliArgv */
-$cliArgv = $_SERVER['argv'] ?? [];
+/** @var list<string> $argv */
 
-exit(App\Commands\BuildCommand::runFromArgv($cliArgv));
+exit(App\Commands\BuildCommand::runFromArgv($argv));

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -628,6 +628,19 @@ pub extern "C" fn pico_array_get_str(arr: *const PicoArray, index: i32) -> *cons
     }
 }
 
+// -- argv -------------------------------------------------------------------
+
+/// Convert C main(argc, argv) into a PicoArray of strings.
+#[no_mangle]
+pub extern "C" fn pico_argv_to_array(argc: c_int, argv: *const *const c_char) -> *mut PicoArray {
+    let mut data = Vec::with_capacity(argc as usize);
+    for i in 0..argc as usize {
+        let ptr = unsafe { *argv.add(i) };
+        data.push(PicoValue::Str(ptr));
+    }
+    Box::into_raw(Box::new(PicoArray { data }))
+}
+
 // -- set --------------------------------------------------------------------
 
 #[no_mangle]

--- a/tests/Feature/ArgvTest.php
+++ b/tests/Feature/ArgvTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+it('handles $argc and $argv access', function () {
+    $file = 'tests/programs/functions/argv_access.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->assertPicohpExitCode("build --debug {$file}");
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});
+
+it('handles array_slice on $argv', function () {
+    $file = 'tests/programs/functions/argv_slice.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->assertPicohpExitCode("build --debug {$file}");
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/functions/argv_access.php
+++ b/tests/programs/functions/argv_access.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var int $argc */
+/** @var list<string> $argv */
+
+echo "argc=" . $argc . "\n";
+
+$len = strlen($argv[0]);
+if ($len > 0) {
+    echo "argv0_nonempty\n";
+}
+
+echo "done\n";

--- a/tests/programs/functions/argv_slice.php
+++ b/tests/programs/functions/argv_slice.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var int $argc */
+/** @var list<string> $argv */
+
+/** @var list<string> $rest */
+$rest = array_slice($argv, 1, $argc - 1);
+$count = count($rest);
+echo "rest_count=" . $count . "\n";
+echo "done\n";


### PR DESCRIPTION
## Summary
- Replace `$_SERVER['argv']` with `$argv` in the picoHP entry point, unblocking self-compilation
- Compiler now passes `argc`/`argv` from C `main()` to PHP global code via `pico_argv_to_array` runtime function
- Fix ternary alloca-in-non-entry-block bug (#130) by emitting allocas in the entry block via `createEntryAlloca()`

## Test plan
- [x] New oracle tests: `argv_access.php` (argc + argv[0] access) and `argv_slice.php` (array_slice on argv)
- [x] TernaryTest now passes (was failing due to #130)
- [x] HandLexerTest, SelfCompileTest, BuiltinFunctionTest all pass (were blocked by #130)
- [x] 496 tests pass, 0 failures
- [x] PHPStan clean

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)