### PR TITLE
feat: LLVM DWARF debug metadata for source-level debugging

### DIFF
--- a/app/Commands/BuildCommand.php
+++ b/app/Commands/BuildCommand.php
@@ -148,7 +148,7 @@ final class BuildCommand
             mkdir($buildPath, 0700, true);
             // @codeCoverageIgnoreEnd
         } else {
-            exec("rm -f {$buildPath}/*");
+            exec("rm -rf {$buildPath}/*");
         }
         $astOutput = "{$buildPath}/ast.json";
         $transformedCode = "{$buildPath}/transformed_code.php";
@@ -211,7 +211,11 @@ final class BuildCommand
                 file_put_contents($astWithSymbolOutput, json_encode($transformedAst, JSON_PRETTY_PRINT));
             }
 
-            $pass = new IRGenerationPass($transformedAst, $semanticPass->getClassRegistry(), $semanticPass->getEnumRegistry(), $semanticPass->getTypeIdMap());
+            $resolvedFile = is_file($filename) ? realpath($filename) : null;
+            if ($resolvedFile === false) {
+                $resolvedFile = null;
+            }
+            $pass = new IRGenerationPass($transformedAst, $semanticPass->getClassRegistry(), $semanticPass->getEnumRegistry(), $semanticPass->getTypeIdMap(), $resolvedFile);
             $pass->exec();
 
             $f = fopen($llvmIRoutput, 'w');
@@ -253,7 +257,8 @@ final class BuildCommand
             $runtimePath = config('app.runtime_path');
             \App\PicoHP\CompilerInvariant::check(is_string($runtimePath));
             $runtimeLink = "-L{$runtimePath} -lpico_rt -Wl,-rpath,{$runtimePath}";
-            exec("{$llvmPath}/clang -Wno-override-module {$sharedLibOpts} {$runtimeLink} -o {$exe} {$optimizedIR}", result_code: $result);
+            $debugFlag = $resolvedFile !== null ? '-g' : '';
+            exec("{$llvmPath}/clang -Wno-override-module {$debugFlag} {$sharedLibOpts} {$runtimeLink} -o {$exe} {$optimizedIR}", result_code: $result);
             // @codeCoverageIgnoreStart
             if ($result !== 0) {
                 $io->error("clang failed with exit code {$result}");

--- a/app/PicoHP/LLVM/Builder.php
+++ b/app/PicoHP/LLVM/Builder.php
@@ -542,10 +542,25 @@ class Builder
     //     return $resultVal;
     // }
 
+    protected ?int $currentDbgLine = null;
+
+    /**
+     * Set the current source line for debug metadata. Subsequent instructions
+     * will be annotated with !dbg for this line until changed.
+     */
+    public function setDebugLine(?int $line): void
+    {
+        $this->currentDbgLine = $line;
+    }
+
     public function addLine(string $line = '', int $indent = 0): void
     {
+        $dbgRef = null;
+        if ($indent > 0 && $this->currentDbgLine !== null && $line !== '') {
+            $dbgRef = $this->module->getDebugInfo()->getLocation($this->currentDbgLine);
+        }
         if ($this->currentBasicBlock !== null) {
-            $this->currentBasicBlock->addLine(new IRLine($line, $indent));
+            $this->currentBasicBlock->addLine(new IRLine($line, $indent, $dbgRef));
         } else {
             $this->module->addLine(new IRLine($line));
         }

--- a/app/PicoHP/LLVM/DebugInfo.php
+++ b/app/PicoHP/LLVM/DebugInfo.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\PicoHP\LLVM;
+
+/**
+ * Manages LLVM debug metadata nodes (!DI* entries) for DWARF emission.
+ * Each node gets a unique ID (!0, !1, ...) and is emitted at the end of the module.
+ */
+class DebugInfo
+{
+    private int $nextId = 0;
+
+    /** @var array<int, string> id → metadata node text */
+    private array $nodes = [];
+
+    private ?int $compileUnitId = null;
+    private ?int $fileId = null;
+
+    /** @var array<string, int> function name → DISubprogram id */
+    private array $subprograms = [];
+
+    /** @var array<string, int> "file:line" → DILocation id (cache) */
+    private array $locationCache = [];
+
+    private ?int $currentScope = null;
+
+    public function addNode(string $text): int
+    {
+        $id = $this->nextId++;
+        $this->nodes[$id] = $text;
+        return $id;
+    }
+
+    public function initCompileUnit(string $filename, string $directory): void
+    {
+        $this->fileId = $this->addNode("!DIFile(filename: \"{$filename}\", directory: \"{$directory}\")");
+        $this->compileUnitId = $this->addNode(
+            "distinct !DICompileUnit(language: DW_LANG_C, file: !{$this->fileId}, producer: \"picoHP\", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)"
+        );
+    }
+
+    public function getFileId(): ?int
+    {
+        return $this->fileId;
+    }
+
+    public function getCompileUnitId(): ?int
+    {
+        return $this->compileUnitId;
+    }
+
+    public function addSubprogram(string $funcName, int $line, ?int $fileId = null): int
+    {
+        $fid = $fileId ?? $this->fileId;
+        \App\PicoHP\CompilerInvariant::check($fid !== null);
+        $spTypeId = $this->addNode('!DISubroutineType(types: !{})');
+        $id = $this->addNode(
+            "distinct !DISubprogram(name: \"{$funcName}\", scope: !{$fid}, file: !{$fid}, line: {$line}, type: !{$spTypeId}, scopeLine: {$line}, unit: !{$this->compileUnitId}, spFlags: DISPFlagDefinition)"
+        );
+        $this->subprograms[$funcName] = $id;
+        return $id;
+    }
+
+    public function getSubprogramId(string $funcName): ?int
+    {
+        return $this->subprograms[$funcName] ?? null;
+    }
+
+    public function setCurrentScope(?int $scopeId): void
+    {
+        $this->currentScope = $scopeId;
+    }
+
+    public function getCurrentScope(): ?int
+    {
+        return $this->currentScope;
+    }
+
+    /**
+     * Get or create a DILocation for the given line. Returns metadata node ID.
+     */
+    public function getLocation(int $line, int $column = 0): ?int
+    {
+        if ($this->currentScope === null) {
+            return null;
+        }
+        $key = "{$this->currentScope}:{$line}:{$column}";
+        if (isset($this->locationCache[$key])) {
+            return $this->locationCache[$key];
+        }
+        $id = $this->addNode("!DILocation(line: {$line}, column: {$column}, scope: !{$this->currentScope})");
+        $this->locationCache[$key] = $id;
+        return $id;
+    }
+
+    /**
+     * @return array<string> Lines to append at end of module
+     */
+    public function getMetadataLines(): array
+    {
+        if ($this->compileUnitId === null) {
+            return [];
+        }
+        $lines = [];
+        $lines[] = '';
+        $lines[] = '!llvm.dbg.cu = !{!' . $this->compileUnitId . '}';
+        $lines[] = '!llvm.module.flags = !{!' . $this->addNode('!{i32 2, !"Debug Info Version", i32 3}') . ', !' . $this->addNode('!{i32 7, !"Dwarf Version", i32 4}') . '}';
+        $lines[] = '';
+        foreach ($this->nodes as $id => $text) {
+            $lines[] = "!{$id} = {$text}";
+        }
+        return $lines;
+    }
+}

--- a/app/PicoHP/LLVM/Function_.php
+++ b/app/PicoHP/LLVM/Function_.php
@@ -17,6 +17,9 @@ class Function_ implements NodeInterface
     /** When true, this function returns a %result struct instead of the raw type. */
     public bool $canThrow = false;
 
+    /** DWARF DISubprogram metadata node ID, if debug info is enabled. */
+    public ?int $dbgSubprogramId = null;
+
     /**
      * @var array<PicoType>
      */
@@ -80,7 +83,8 @@ class Function_ implements NodeInterface
         $retTypeStr = $this->canThrow
             ? Builder::resultTypeName($this->returnType->toBase())
             : $this->returnType->toBase()->toLLVM();
-        $code[] = new IRLine("define dso_local {$retTypeStr} @{$this->name}({$paramString}) {");
+        $dbgSuffix = $this->dbgSubprogramId !== null ? " !dbg !{$this->dbgSubprogramId}" : '';
+        $code[] = new IRLine("define dso_local {$retTypeStr} @{$this->name}({$paramString}){$dbgSuffix} {");
         foreach ($this->getChildren() as $bb) {
             \App\PicoHP\CompilerInvariant::check($bb instanceof BasicBlock);
             $code = array_merge($code, $bb->getLines());

--- a/app/PicoHP/LLVM/IRLine.php
+++ b/app/PicoHP/LLVM/IRLine.php
@@ -6,15 +6,21 @@ class IRLine
 {
     private string $text;
     private int $indent;
+    private ?int $dbgRef;
 
-    public function __construct(string $text = '', int $indent = 0)
+    public function __construct(string $text = '', int $indent = 0, ?int $dbgRef = null)
     {
         $this->text = $text;
         $this->indent = $indent;
+        $this->dbgRef = $dbgRef;
     }
 
     public function toString(): string
     {
-        return str_repeat(' ', $this->indent * 4) . $this->text;
+        $line = str_repeat(' ', $this->indent * 4) . $this->text;
+        if ($this->dbgRef !== null) {
+            $line .= ", !dbg !{$this->dbgRef}";
+        }
+        return $line;
     }
 }

--- a/app/PicoHP/LLVM/Module.php
+++ b/app/PicoHP/LLVM/Module.php
@@ -15,6 +15,7 @@ class Module implements NodeInterface
 
     protected string $name;
     protected Builder $builder;
+    protected DebugInfo $debugInfo;
 
     /**
      * @var array<IRLine>
@@ -25,6 +26,7 @@ class Module implements NodeInterface
     {
         $this->name = $name;
         $this->builder = new Builder($this, "arm64-apple-macosx14.0.0", "e-m:o-i64:64-i128:128-n32:64-S128");
+        $this->debugInfo = new DebugInfo();
         Instruction::resetCounter();
     }
 
@@ -51,6 +53,11 @@ class Module implements NodeInterface
     public function getBuilder(): Builder
     {
         return $this->builder;
+    }
+
+    public function getDebugInfo(): DebugInfo
+    {
+        return $this->debugInfo;
     }
 
     public function getName(): string
@@ -86,6 +93,9 @@ class Module implements NodeInterface
     {
         foreach ($this->getLines() as $line) {
             fwrite($file, $line->toString() . PHP_EOL);
+        }
+        foreach ($this->debugInfo->getMetadataLines() as $metaLine) {
+            fwrite($file, $metaLine . PHP_EOL);
         }
     }
 }

--- a/app/PicoHP/Pass/IRGenerationPass.php
+++ b/app/PicoHP/Pass/IRGenerationPass.php
@@ -34,6 +34,8 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
     /** @var array<string, int> class name => type_id */
     protected array $typeIdMap = [];
 
+    protected ?string $sourceFile = null;
+
     protected int $vdispatchCount = 0;
 
     /**
@@ -71,7 +73,13 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
      * @param array<string, EnumMetadata> $enumRegistry
      * @param array<string, int> $typeIdMap
      */
-    public function __construct(array $stmts, array $classRegistry = [], array $enumRegistry = [], array $typeIdMap = [])
+    /**
+     * @param array<\PhpParser\Node> $stmts
+     * @param array<string, ClassMetadata> $classRegistry
+     * @param array<string, EnumMetadata> $enumRegistry
+     * @param array<string, int> $typeIdMap
+     */
+    public function __construct(array $stmts, array $classRegistry = [], array $enumRegistry = [], array $typeIdMap = [], ?string $sourceFile = null)
     {
         $this->module = new Module("test_module");
         $this->builder = $this->module->getBuilder();
@@ -79,6 +87,7 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
         $this->classRegistry = $classRegistry;
         $this->enumRegistry = $enumRegistry;
         $this->typeIdMap = $typeIdMap;
+        $this->sourceFile = $sourceFile;
     }
 
     protected function pushNamespace(?string $namespace): void
@@ -102,6 +111,11 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
 
     public function exec(): void
     {
+        if ($this->sourceFile !== null) {
+            $dir = dirname($this->sourceFile);
+            $file = basename($this->sourceFile);
+            $this->module->getDebugInfo()->initCompileUnit($file, $dir);
+        }
         $this->emitStructDefinitionsForRegistry();
         $this->emitBuiltinExceptionClass();
         $this->buildStmts($this->stmts);
@@ -170,11 +184,23 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
     public function buildStmt(\PhpParser\Node\Stmt $stmt): void
     {
         $pData = PicoHPData::getPData($stmt);
+        $stmtLine = $stmt->getStartLine();
+        if ($stmtLine > 0 && $this->module->getDebugInfo()->getCurrentScope() !== null) {
+            $this->builder->setDebugLine($stmtLine);
+        }
 
         if ($stmt instanceof \PhpParser\Node\Stmt\Function_) {
             $funcSymbol = $pData->getSymbol();
             \App\PicoHP\CompilerInvariant::check($funcSymbol->func === true);
             $this->currentFunction = $this->module->addFunction($stmt->name->toString(), $funcSymbol->type, $funcSymbol->params, $funcSymbol->canThrow);
+            $debugInfo = $this->module->getDebugInfo();
+            if ($debugInfo->getCompileUnitId() !== null) {
+                $line = $stmt->getStartLine();
+                $spId = $debugInfo->addSubprogram($stmt->name->toString(), max($line, 1));
+                $this->currentFunction->dbgSubprogramId = $spId;
+                $debugInfo->setCurrentScope($spId);
+                $this->builder->setDebugLine(max($line, 1));
+            }
             $bb = $this->currentFunction->addBasicBlock("entry");
             $this->builder->setInsertPoint($bb);
             if ($pData->stubbed) {
@@ -208,6 +234,8 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
                     $this->builder->createRetVoid();
                 }
             }
+            $this->module->getDebugInfo()->setCurrentScope(null);
+            $this->builder->setDebugLine(null);
         } elseif ($stmt instanceof \PhpParser\Node\Stmt\Block) {
             $scope = $pData->getScope();
             foreach ($scope->symbols as $symbol) {
@@ -658,6 +686,10 @@ class IRGenerationPass implements \App\PicoHP\PassInterface
     public function buildExpr(\PhpParser\Node\Expr $expr, ?\PhpParser\Comment\Doc $doc = null): ValueAbstract
     {
         $pData = PicoHPData::getPData($expr);
+        $exprLine = $expr->getStartLine();
+        if ($exprLine > 0 && $this->module->getDebugInfo()->getCurrentScope() !== null) {
+            $this->builder->setDebugLine($exprLine);
+        }
 
         if ($expr instanceof \PhpParser\Node\Expr\Assign) {
             // List/array destructuring: [$a, $b] = $arr

--- a/tests/Feature/DebugInfoTest.php
+++ b/tests/Feature/DebugInfoTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+it('emits DWARF debug metadata in generated IR', function () {
+    $file = 'tests/programs/functions/debug_info_probe.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->assertPicohpExitCode("build --debug {$file}");
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+
+    $ir = file_get_contents("{$buildPath}/out.ll");
+    assert(is_string($ir));
+
+    // Compile unit and file metadata
+    expect($ir)->toContain('!llvm.dbg.cu');
+    expect($ir)->toContain('!DICompileUnit');
+    expect($ir)->toContain('!DIFile(filename: "debug_info_probe.php"');
+
+    // Function has !dbg attached
+    expect($ir)->toMatch('/define.*@add\(.*\) !dbg !\d+/');
+    expect($ir)->toMatch('/define.*@main\(.*\) !dbg !\d+/');
+
+    // DISubprogram for user function
+    expect($ir)->toContain('!DISubprogram(name: "add"');
+    expect($ir)->toContain('!DISubprogram(name: "main"');
+
+    // Instructions have !dbg locations
+    expect($ir)->toMatch('/call.*@pico_int_to_string.*!dbg !\d+/');
+
+    // DILocation with real line numbers
+    expect($ir)->toMatch('/!DILocation\(line: 10/');  // $result = add(3, 4);
+    expect($ir)->toMatch('/!DILocation\(line: 11/');  // echo ...
+});
+
+it('produces correct oracle output with debug info', function () {
+    $file = 'tests/programs/functions/debug_info_probe.php';
+
+    /** @phpstan-ignore-next-line */
+    $this->assertPicohpExitCode("build --debug {$file}");
+
+    $buildPath = config('app.build_path');
+    assert(is_string($buildPath));
+    $compiled_output = shell_exec("{$buildPath}/a.out");
+    $php_output = shell_exec("php {$file}");
+
+    expect($compiled_output)->toBe($php_output);
+});

--- a/tests/programs/functions/debug_info_probe.php
+++ b/tests/programs/functions/debug_info_probe.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+function add(int $a, int $b): int
+{
+    return $a + $b;
+}
+
+$result = add(3, 4);
+echo $result . "\n";


### PR DESCRIPTION
## Summary
- Emit LLVM debug metadata (DICompileUnit, DIFile, DISubprogram, DILocation) so debuggers can map compiled binaries to PHP source lines
- Every instruction inside functions gets `!dbg` annotations with correct source line numbers
- `lldb` can now set breakpoints, show PHP source, and produce meaningful stack traces for compiled programs
- New `DebugInfo` class manages metadata node registry with unique IDs

## Demo
```
(lldb) b main
Breakpoint 1: where = a.out`main + 8 at argv_access.php:1
(lldb) bt
* frame #0: a.out`main at argv_access.php:1
(lldb) source list
   8    echo "argc=" . $argc . "\n";
   10   $len = strlen($argv[0]);
```

## Test plan
- [x] New `DebugInfoTest` verifies metadata presence in IR (DICompileUnit, DIFile, DISubprogram, DILocation with correct line numbers)
- [x] Oracle test confirms output correctness unchanged
- [x] Verified lldb resolves PHP source lines from compiled binary
- [x] 499 tests pass, PHPStan clean

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)